### PR TITLE
Fix for issue #18

### DIFF
--- a/src/PopupContainer.js
+++ b/src/PopupContainer.js
@@ -7,6 +7,6 @@ export default class PopupContainer extends MapLayer {
     const children = this.getClonedChildrenWithMap({
       popupContainer: this.leafletElement
     });
-    return <noscript>{children}</noscript>;
+    return <div>{children}</div>;
   }
 }


### PR DESCRIPTION
Changing the element from `noscript` to, for example, `div` fixes the `Error: Invariant Violation: findComponentRoot`, which is experienced by both flummox users and raised when the browser navigation’s back and forward is used. See https://github.com/PaulLeCam/react-leaflet/issues/18