### PR TITLE
Fixed exporting of PopupContainer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import MultiPolyline from "./MultiPolyline";
 import Polygon from "./Polygon";
 import Polyline from "./Polyline";
 import Popup from "./Popup";
-import PopupContainer from "./Popup";
+import PopupContainer from "./PopupContainer";
 import Rectangle from "./Rectangle";
 import TileLayer from "./TileLayer";
 import WMSTileLayer from "./WMSTileLayer";


### PR DESCRIPTION
PopupContainer will export PopupContainer instead of Popup.

It actually gave me a hard time to figure out why my own Leaflet elements inherited from PopupContainer did not render. It turned out that the PopupContainer was exporting Popup instead. After fixing this everything worked as expected.