### PR TITLE
Fix ignored events when there is an attribute named "length" in a layer

### DIFF
--- a/example/events.js
+++ b/example/events.js
@@ -37,10 +37,11 @@ export default class EventsExample extends Component {
       center={this.state.latlng}
       zoom={13}
       onClick={this.handleClick.bind(this)}
-      onLocationfound={this.handleLocationFound.bind(this)}>
+      onLocationfound={this.handleLocationFound.bind(this)}
+      length={4}>
       <TileLayer
         url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
-        attribution='&copy; <a href='http://osm.org/copyright'>OpenStreetMap</a> contributors'
+        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
       />
       {marker}
     </Map>;

--- a/example/simple.js
+++ b/example/simple.js
@@ -16,7 +16,7 @@ export default class SimpleExample extends Component {
     return <Map center={position} zoom={this.state.zoom}>
       <TileLayer
         url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
-        attribution='&copy; <a href='http://osm.org/copyright'>OpenStreetMap</a> contributors'
+        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
       />
       <Marker position={position}>
         <Popup>

--- a/example/vector-layers.js
+++ b/example/vector-layers.js
@@ -46,7 +46,7 @@ export default class VectorLayersExample extends Component {
     return <Map center={center} zoom={13}>
       <TileLayer
         url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
-        attribution='&copy; <a href='http://osm.org/copyright'>OpenStreetMap</a> contributors'
+        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
       />
       <Circle center={center} radius={200} fillColor='blue' />
       <CircleMarker center={[51.51, -0.12]} radius={20} color='red'>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var logTime = function(fileName) {
     var time = ms < 1000
       ? $.util.colors.magenta(ms + ' ms')
       : $.util.colors.magenta(ms / 1000 + ' s');
-    $.util.log('Browserified '' +  name + '' in ' + time);
+    $.util.log('Browserified "' +  name + '" in ' + time);
   };
 };
 

--- a/src/MapComponent.js
+++ b/src/MapComponent.js
@@ -1,6 +1,7 @@
 import clone from 'lodash/lang/clone';
 import forEach from 'lodash/collection/forEach';
 import reduce from 'lodash/collection/reduce';
+import keys from 'lodash/object/keys';
 import { Component } from 'react';
 
 const EVENTS_RE = /on(?:Leaflet)?(.+)/i;
@@ -11,10 +12,10 @@ export default class MapComponent extends Component {
   }
 
   extractLeafletEvents(props) {
-    return reduce(props, (res, cb, ev) => {
+    return reduce(keys(props), (res, ev) => {
       if (EVENTS_RE.test(ev)) {
         const key = ev.replace(EVENTS_RE, (match, p) => p.toLowerCase());
-        res[ key ] = cb;
+        res[ key ] = props[ev];
       }
       return res;
     }, {});


### PR DESCRIPTION
It fixes an issue when a layer component had a length attribute, lodash see the object as an array so the events couldn't be extracted.

Also fix nested simple quote issues after a blind double to simple quote replace.
I didn't included the generated files.