### PR TITLE
Add bower.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+bower_components
 coverage

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "react-leaflet",
+  "version": "0.6.2",
+  "homepage": "https://github.com/PaulLeCam/react-leaflet",
+  "authors": [
+    "Paul Le Cam <paul@ulem.net>"
+  ],
+  "description": "React components for Leaflet maps",
+  "main": "lib/index.js",
+  "dependencies": {
+    "lodash": "~3.0.0",
+    "leaflet": "~0.7.0",
+    "react": "~0.13.0"
+  },
+  "keywords": [
+    "react-component",
+    "react",
+    "leaflet",
+    "map"
+  ],
+  "moduleType": [
+    "node"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "node_modules",
+    "bower_components"
+  ]
+}


### PR DESCRIPTION
I use this library in conjunction with the [Rails Assets proxy](https://rails-assets.org/) to use bower dependencies in my gem file. Unfortunately this library does not provide a bower.json file and is therefore not part of the bower registry.

This PR adds a `bower.json` file. The registration must be done by the author.