### PR TITLE
Fix latLngList not supporting polygons with holes

### DIFF
--- a/src/types/latlngList.js
+++ b/src/types/latlngList.js
@@ -2,4 +2,7 @@ import { PropTypes } from 'react';
 
 import latlng from './latlng';
 
-export default PropTypes.arrayOf(latlng);
+export default PropTypes.oneOfType([
+  PropTypes.arrayOf(latlng),
+  PropTypes.arrayOf(PropTypes.arrayOf(latlng))
+]);


### PR DESCRIPTION
see http://leafletjs.com/reference.html#polygon
When creating polygons with holes react-leflet complains is has wrong params.
Array of arrays of latlngs should also be allowed since Leaflet supports them.