### PR TITLE
Optimise marker and polygon componentDidUpdate

### DIFF
--- a/src/Marker.js
+++ b/src/Marker.js
@@ -22,7 +22,7 @@ export default class Marker extends PopupContainer {
     if (this.props.position !== prevProps.position) {
       if (!Leaflet.latLng(this.props.position).equals(this.leafletElement.getLatLng())) {
         this.leafletElement.setLatLng(this.props.position);
-        if(this.props.layerGroup && this.props.layerGroup.constructor === L.MarkerClusterGroup) {
+        if (this.props.layerGroup && this.props.layerGroup.constructor === L.MarkerClusterGroup) {
           this.props.layerGroup.removeLayer(this.leafletElement);
           this.props.layerGroup.addLayer(this.leafletElement);
         }

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -20,7 +20,16 @@ export default class Marker extends PopupContainer {
 
   componentDidUpdate(prevProps) {
     if (this.props.position !== prevProps.position) {
-      this.leafletElement.setLatLng(this.props.position);
+      if (!Leaflet.latLng(this.props.position).equals(this.leafletElement.getLatLng())) {
+        this.leafletElement.setLatLng(this.props.position);
+        if(this.props.layerGroup && this.props.layerGroup.constructor === L.MarkerClusterGroup) {
+          this.props.layerGroup.removeLayer(this.leafletElement);
+          this.props.layerGroup.addLayer(this.leafletElement);
+        }
+      }
+    }
+    if (this.props.icon !== prevProps.icon) {
+      this.leafletElement.setIcon(this.props.icon)
     }
     if (this.props.icon !== prevProps.icon) {
       this.leafletElement.setIcon(this.props.icon);

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -29,9 +29,6 @@ export default class Marker extends PopupContainer {
       }
     }
     if (this.props.icon !== prevProps.icon) {
-      this.leafletElement.setIcon(this.props.icon)
-    }
-    if (this.props.icon !== prevProps.icon) {
       this.leafletElement.setIcon(this.props.icon);
     }
     if (this.props.zIndexOffset !== prevProps.zIndexOffset) {

--- a/src/Polygon.js
+++ b/src/Polygon.js
@@ -1,7 +1,10 @@
 import Leaflet from 'leaflet';
+import isEqual from 'lodash/lang/isEqual';
+import find from 'lodash/collection/find';
 
 import latlngListType from './types/latlngList';
 import PopupContainer from './PopupContainer';
+
 
 export default class Polygon extends PopupContainer {
   componentWillMount() {
@@ -12,7 +15,14 @@ export default class Polygon extends PopupContainer {
 
   componentDidUpdate(prevProps) {
     if (this.props.positions !== prevProps.positions) {
-      this.leafletElement.setLatLngs(this.props.positions);
+      if(!isEqual(this.props.positions, prevProps.positions)){
+        this.leafletElement.setLatLngs(this.props.positions);
+      }
+    }
+    const styleProperties = ['stroke','color','weight','opacity','fill','fillColor',
+                              'fillOpacity','dashArray','lineCap','className']
+    if(find(styleProperties, (prop)=> this.props[prop] !== prevProps[prop], this) ) {
+      this.leafletElement.setStyle(this.props)
     }
   }
 }

--- a/src/Polygon.js
+++ b/src/Polygon.js
@@ -15,14 +15,14 @@ export default class Polygon extends PopupContainer {
 
   componentDidUpdate(prevProps) {
     if (this.props.positions !== prevProps.positions) {
-      if(!isEqual(this.props.positions, prevProps.positions)){
+      if (!isEqual(this.props.positions, prevProps.positions)) {
         this.leafletElement.setLatLngs(this.props.positions);
       }
     }
     const styleProperties = ['stroke','color','weight','opacity','fill','fillColor',
                               'fillOpacity','dashArray','lineCap','className']
-    if(find(styleProperties, (prop)=> this.props[prop] !== prevProps[prop], this) ) {
-      this.leafletElement.setStyle(this.props)
+    if ( find(styleProperties, (prop)=> this.props[prop] !== prevProps[prop], this) ) {
+      this.leafletElement.setStyle(this.props);
     }
   }
 }


### PR DESCRIPTION
This is an optimisation I use so that if a marker or a polygon are re-rendered often the DOM is not touched if their props didn't change. 
The previous approach only works with immutable latLng and positions objects and it's sometimes difficult to achieve that. This fixes it a little.