### PR TITLE
New component: LayerGroup 

### DIFF
--- a/src/LayerGroup.js
+++ b/src/LayerGroup.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Leaflet from 'leaflet';
+import MapLayer from './MapLayer';
+import { layerGroup } from 'leaflet';
+
+export default class LayerGroup extends MapLayer {
+  componentDidMount() {
+    super.componentDidMount();
+    (this.props.layerGroup || this.props.map).addLayer(this.leafletElement);
+  }
+
+  componentWillMount() {
+    super.componentWillMount();
+    const { map, ...props } = this.props;
+    this.leafletElement = layerGroup();
+  }
+
+  render() {
+    const layerGroup = this.leafletElement;
+    const map = this.props.map
+    const children = React.Children.map(this.props.children, child => {
+      return child ? React.cloneElement(child, {map, layerGroup}) : null;
+    });
+
+    return <div>{children}</div>;
+  }
+}

--- a/src/LayerGroup.js
+++ b/src/LayerGroup.js
@@ -17,7 +17,7 @@ export default class LayerGroup extends MapLayer {
 
   render() {
     const layerGroup = this.leafletElement;
-    const map = this.props.map
+    const map = this.props.map;
     const children = React.Children.map(this.props.children, child => {
       return child ? React.cloneElement(child, {map, layerGroup}) : null;
     });

--- a/src/MapLayer.js
+++ b/src/MapLayer.js
@@ -5,12 +5,12 @@ import MapComponent from './MapComponent'
 export default class MapLayer extends MapComponent {
   componentDidMount() {
     super.componentDidMount();
-    this.props.map.addLayer(this.leafletElement);
+    (this.props.layerGroup || this.props.map).addLayer(this.leafletElement);
   }
 
   componentWillUnmount() {
     super.componentWillUnmount();
-    this.props.map.removeLayer(this.leafletElement);
+    (this.props.layerGroup || this.props.map).removeLayer(this.leafletElement);
   }
 
   getClonedChildrenWithMap(extra) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import CanvasTileLayer from './CanvasTileLayer';
 import Circle from './Circle';
 import CircleMarker from './CircleMarker';
 import FeatureGroup from './FeatureGroup';
+import LayerGroup from './LayerGroup';
 import GeoJson from './GeoJson';
 import ImageOverlay from './ImageOverlay';
 import Map from './Map';
@@ -37,6 +38,7 @@ export default {
   Circle,
   CircleMarker,
   FeatureGroup,
+  LayerGroup,
   GeoJson,
   ImageOverlay,
   Map,


### PR DESCRIPTION
It can wrap other layers inside itself. (http://leafletjs.com/reference.html#layergroup)
I used this a as basis for MarkerClusterGroup to enable clustering capabilities using leaflet-markercluster plugin. (see my other PR)
I also think the FeatureGroup component should extend this one so it can actually wrap other react-leflet components not just regular Leaflet objects