### PR TITLE
Popup content working using react 

### DIFF
--- a/src/Popup.js
+++ b/src/Popup.js
@@ -11,45 +11,54 @@ export default class Popup extends MapComponent {
 
   componentWillMount() {
     super.componentWillMount();
-    const { children, map, ...props } = this.props;
-    this.leafletElement = popup(props);
+    const { children, map, popupContainer, ...props } = this.props;
+    this.leafletElement = popup(props, popupContainer);
+    this.leafletElement.on('open', () => { //on popoup create new react root
+      const {children} = this.props
+      this.contentComponent = React.render(React.DOM.div({children}), this.leafletElement._contentNode)
+      this.leafletElement._adjustPan()
+    }, this)
+    this.leafletElement.on('close', () => { //remove react root
+      delete this.contentComponent
+      React.unmountComponentAtNode(this.leafletElement._contentNode)
+    }, this)
+  }
+
+  componentDidMount() {
+    const { popupContainer, map, position } = this.props;
+    super.componentDidMount();
+    //Attach to container component
+    if (popupContainer) {
+      popupContainer.bindPopup(this.leafletElement)
+    } else { //attach to map
+      if(position) this.leafletElement.setLatLng(position)
+      this.leafletElement.openOn(map)
+    }
   }
 
   componentDidUpdate(prevProps) {
-    const { children, map, popupContainer, position, ...props } = this.props;
-    if (children !== prevProps.children) {
-      const content = React.renderToStaticMarkup(children);
-      if (popupContainer) {
-        popupContainer.bindPopup(content, props);
-      }
-      else {
-        const el = this.leafletElement;
-        el.setContent(content);
-        if (position !== prevProps.position) el.setLatLng(position);
-      }
+    const { children, popupContainer, position } = this.props;
+    if(!popupContainer) {
+      if (position !== prevProps.position) this.leafletElement.setLatLng(position);
+    }
+    if(this.contentComponent) {
+      this.contentComponent = React.render(React.DOM.div({children}), this.leafletElement._contentNode)
     }
   }
 
   componentWillUnmount() {
+    const { map, popupContainer } = this.props;
     super.componentWillUnmount();
-    this.props.map.removeLayer(this.leafletElement);
-  }
-
-  render() {
-    const { children, map, popupContainer, position, ...props } = this.props;
-    if (children) {
-      const content = React.renderToStaticMarkup(children);
-      // Attach to container component
-      if (popupContainer) {
-        popupContainer.bindPopup(content, props);
-        return null;
-      }
-      // Attach to a Map
-      const el = this.leafletElement;
-      el.setContent(content);
-      if (position) el.setLatLng(position);
-      el.openOn(map);
+    if(this.leafletElement._contentNode) {
+      React.unmountComponentAtNode(this.leafletElement._contentNode);
     }
+    if(popupContainer) {
+      popupContainer.unbindPopup(this.leafletElement);
+    } else {
+      map.removeLayer(this.leafletElement)
+    }
+  }
+  render() {
     return null;
   }
 }

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -14,14 +14,14 @@ export default class Popup extends MapComponent {
     const { children, map, popupContainer, ...props } = this.props;
     this.leafletElement = popup(props, popupContainer);
     this.leafletElement.on('open', () => { //on popoup create new react root
-      const {children} = this.props
-      this.contentComponent = React.render(React.DOM.div({children}), this.leafletElement._contentNode)
-      this.leafletElement._adjustPan()
-    }, this)
+      const {children} = this.props;
+      this.contentComponent = React.render(React.DOM.div({children}), this.leafletElement._contentNode);
+      this.leafletElement._adjustPan();
+    })
     this.leafletElement.on('close', () => { //remove react root
-      delete this.contentComponent
-      React.unmountComponentAtNode(this.leafletElement._contentNode)
-    }, this)
+      delete this.contentComponent;
+      React.unmountComponentAtNode(this.leafletElement._contentNode);
+    })
   }
 
   componentDidMount() {
@@ -29,33 +29,33 @@ export default class Popup extends MapComponent {
     super.componentDidMount();
     //Attach to container component
     if (popupContainer) {
-      popupContainer.bindPopup(this.leafletElement)
+      popupContainer.bindPopup(this.leafletElement);
     } else { //attach to map
-      if(position) this.leafletElement.setLatLng(position)
-      this.leafletElement.openOn(map)
+      if (position) this.leafletElement.setLatLng(position);
+      this.leafletElement.openOn(map);
     }
   }
 
   componentDidUpdate(prevProps) {
     const { children, popupContainer, position } = this.props;
-    if(!popupContainer) {
+    if (!popupContainer) {
       if (position !== prevProps.position) this.leafletElement.setLatLng(position);
     }
-    if(this.contentComponent) {
-      this.contentComponent = React.render(React.DOM.div({children}), this.leafletElement._contentNode)
+    if (this.contentComponent) {
+      this.contentComponent = React.render(React.DOM.div({children}), this.leafletElement._contentNode);
     }
   }
 
   componentWillUnmount() {
     const { map, popupContainer } = this.props;
     super.componentWillUnmount();
-    if(this.leafletElement._contentNode) {
+    if (this.leafletElement._contentNode) {
       React.unmountComponentAtNode(this.leafletElement._contentNode);
     }
-    if(popupContainer) {
+    if (popupContainer) {
       popupContainer.unbindPopup(this.leafletElement);
     } else {
-      map.removeLayer(this.leafletElement)
+      map.removeLayer(this.leafletElement);
     }
   }
   render() {


### PR DESCRIPTION
Replaced react.renderToStaticMarkup with proper react.render to allow for dom diffing and dynamic updates on popup content.
There is still a single child limitation ie. <Popup> can only have one child, but apart from that anything placed inside the popup will behave like normal react.dom content with proper diffing and updating when popup is opened.
It works by creating a new react root each time a popup is opened and scrubbing it if it closed