### PR TITLE
Downgrade jest-cli to 0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gulp-load-plugins": "^0.10.0",
     "gulp-util": "^3.0.5",
     "gulp-webserver": "^0.9.1",
-    "jest-cli": "^0.5.0",
+    "jest-cli": "^0.4.0",
     "leaflet": "^0.7.3",
     "onchange": "^1.1.0",
     "react": "^0.13.3",


### PR DESCRIPTION
Because of this issue:

http://stackoverflow.com/questions/32114367/reactjs-jestjsdom-4-x-onward-only-works-on-io-js-not-node-jst

I'm downgrading `jest-cli` to 0.4 -- feel free to ignore but this was just a frustration while trying to get started contributing.