### PR TITLE
Add other controls in v1 TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,19 @@ Extended `LayerGroup` supporting a `Popup` child.
 
 #### Controls
 
+##### AttributionControl
+
+- `position: controlPosition` (optional, dynamic)
+- `prefix: string` (optional)
+
+##### ScaleControl
+
+- `imperial: bool` (optional)
+- `position: controlPosition` (optional, dynamic)
+- `maxWidth: number` (optional)
+- `metric: bool` (optional)
+- `updateWhenIdle: bool` (optional)
+
 ##### ZoomControl
 
 - `position: controlPosition` (optional, dynamic)

--- a/src/AttributionControl.js
+++ b/src/AttributionControl.js
@@ -1,0 +1,14 @@
+import { PropTypes } from 'react';
+import { control } from 'leaflet';
+
+import MapControl from './MapControl';
+
+export default class AttributionControl extends MapControl {
+  static propTypes = {
+    prefix: PropTypes.string,
+  };
+
+  componentWillMount() {
+    this.leafletElement = control.attribution(this.props);
+  }
+}

--- a/src/LayersControl.js
+++ b/src/LayersControl.js
@@ -1,0 +1,17 @@
+import { PropTypes } from 'react';
+import { control } from 'leaflet';
+
+import MapControl from './MapControl';
+
+export default class LayersControl extends MapControl {
+  static propTypes = {
+    baseLayers: PropTypes.object,
+    options: PropTypes.object,
+    overlays: PropTypes.object,
+  };
+
+  componentWillMount() {
+    const { baseLayers, overlays, options } = this.props;
+    this.leafletElement = control.layers(baseLayers, overlays, options);
+  }
+}

--- a/src/ScaleControl.js
+++ b/src/ScaleControl.js
@@ -1,0 +1,17 @@
+import { PropTypes } from 'react';
+import { control } from 'leaflet';
+
+import MapControl from './MapControl';
+
+export default class ZoomControl extends MapControl {
+  static propTypes = {
+    imperial: PropTypes.bool,
+    maxWidth: PropTypes.number,
+    metric: PropTypes.bool,
+    updateWhenIdle: PropTypes.bool,
+  };
+
+  componentWillMount() {
+    this.leafletElement = control.scale(this.props);
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export FeatureGroup from './FeatureGroup';
 export GeoJson from './GeoJson';
 export ImageOverlay from './ImageOverlay';
 export LayerGroup from './LayerGroup';
+export LayersControl from './LayersControl';
 export Map from './Map';
 export MapComponent from './MapComponent';
 export MapControl from './MapControl';

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import Leaflet from 'leaflet';
 
 export * as PropTypes from './types';
 
+export AttributionControl from './AttributionControl';
 export BaseTileLayer from './BaseTileLayer';
 export CanvasTileLayer from './CanvasTileLayer';
 export Circle from './Circle';

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export Polygon from './Polygon';
 export Polyline from './Polyline';
 export Popup from './Popup';
 export Rectangle from './Rectangle';
+export ScaleControl from './ScaleControl';
 export TileLayer from './TileLayer';
 export WMSTileLayer from './WMSTileLayer';
 export ZoomControl from './ZoomControl';


### PR DESCRIPTION
Filling out some of the missing controls in #87.

I've done some basic testing on Attribution and Scale. The Layers control gets placed on the map, but I'm not sure how to correctly pass a base layer reference from a, say, `TileLayer` component into the Layers control.