### PR TITLE
Layer container interface

### DIFF
--- a/src/CanvasTileLayer.js
+++ b/src/CanvasTileLayer.js
@@ -5,7 +5,7 @@ import BaseTileLayer from './BaseTileLayer';
 export default class CanvasTileLayer extends BaseTileLayer {
   componentWillMount() {
     super.componentWillMount();
-    const { map: _, ...props } = this.props;
+    const { map: _map, layerContainer: _lc, ...props } = this.props;
     this.leafletElement = tileLayer.canvas(props);
   }
 }

--- a/src/Circle.js
+++ b/src/Circle.js
@@ -12,7 +12,7 @@ export default class Circle extends Path {
 
   componentWillMount() {
     super.componentWillMount();
-    const { center, map: _, radius, ...props } = this.props;
+    const { center, map: _map, layerContainer: _lc, radius, ...props } = this.props;
     this.leafletElement = circle(center, radius, props);
   }
 

--- a/src/CircleMarker.js
+++ b/src/CircleMarker.js
@@ -12,7 +12,7 @@ export default class CircleMarker extends Path {
 
   componentWillMount() {
     super.componentWillMount();
-    const { center, map: _, ...props } = this.props;
+    const { center, map: _map, layerContainer: _lc, ...props } = this.props;
     this.leafletElement = circleMarker(center, props);
   }
 

--- a/src/GeoJson.js
+++ b/src/GeoJson.js
@@ -10,7 +10,7 @@ export default class GeoJson extends Path {
 
   componentWillMount() {
     super.componentWillMount();
-    const { data, map: _, ...props } = this.props;
+    const { data, map: _map, layerContainer: _lc, ...props } = this.props;
     this.leafletElement = geoJson(data, props);
   }
 

--- a/src/ImageOverlay.js
+++ b/src/ImageOverlay.js
@@ -14,7 +14,7 @@ export default class ImageOverlay extends MapLayer {
 
   componentWillMount() {
     super.componentWillMount();
-    const { bounds, map: _, url, ...props } = this.props;
+    const { bounds, map: _map, layerContainer: _lc, url, ...props } = this.props;
     this.leafletElement = imageOverlay(url, bounds, props);
   }
 

--- a/src/LayerGroup.js
+++ b/src/LayerGroup.js
@@ -10,7 +10,7 @@ export default class LayerGroup extends MapLayer {
 
   render() {
     return this.renderChildrenWithProps({
-      layerGroup: this.leafletElement,
+      layerContainer: this.leafletElement,
     });
   }
 }

--- a/src/Map.js
+++ b/src/Map.js
@@ -88,7 +88,7 @@ export default class Map extends MapComponent {
   render() {
     const map = this.leafletElement;
     const children = map ? React.Children.map(this.props.children, child => {
-      return child ? React.cloneElement(child, {map}) : null;
+      return child ? React.cloneElement(child, {map, layerContainer: map}) : null;
     }) : null;
 
     return (

--- a/src/MapLayer.js
+++ b/src/MapLayer.js
@@ -1,7 +1,7 @@
 import { assign } from 'lodash';
 import React, { PropTypes } from 'react';
 import { Map } from 'leaflet';
-
+import { layerContainer as layerContainerType } from './types';
 import MapComponent from './MapComponent';
 
 export default class MapLayer extends MapComponent {
@@ -10,22 +10,23 @@ export default class MapLayer extends MapComponent {
       PropTypes.arrayOf(PropTypes.node),
       PropTypes.node,
     ]),
-    map: PropTypes.instanceOf(Map),
+    layerContainer: layerContainerType.isRequired,
+    map: PropTypes.instanceOf(Map).isRequired,
   };
 
   componentDidMount() {
     super.componentDidMount();
-    (this.props.layerGroup || this.props.map).addLayer(this.leafletElement);
+    this.props.layerContainer.addLayer(this.leafletElement);
   }
 
   componentWillUnmount() {
     super.componentWillUnmount();
-    (this.props.layerGroup || this.props.map).removeLayer(this.leafletElement);
+    this.props.layerContainer.removeLayer(this.leafletElement);
   }
 
   getClonedChildrenWithMap(extra) {
-    const { children, map } = this.props;
-    const props = assign({map}, extra);
+    const { children, map, layerContainer } = this.props;
+    const props = assign({map, layerContainer}, extra);
 
     return React.Children.map(children, child => {
       return child ? React.cloneElement(child, props) : null;

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -14,7 +14,7 @@ export default class Marker extends MapLayer {
 
   componentWillMount() {
     super.componentWillMount();
-    const { map: _, position, ...props } = this.props;
+    const { map: _map, layerContainer: _lc, position, ...props } = this.props;
     this.leafletElement = marker(position, props);
   }
 

--- a/src/MultiPolygon.js
+++ b/src/MultiPolygon.js
@@ -11,7 +11,7 @@ export default class MultiPolygon extends Path {
 
   componentWillMount() {
     super.componentWillMount();
-    const { map: _, polygons, ...props } = this.props;
+    const { map: _map, layerContainer: _lc, polygons, ...props } = this.props;
     this.leafletElement = multiPolygon(polygons, props);
   }
 

--- a/src/MultiPolyline.js
+++ b/src/MultiPolyline.js
@@ -11,7 +11,7 @@ export default class MultiPolyline extends Path {
 
   componentWillMount() {
     super.componentWillMount();
-    const {map: _, polylines, ...props} = this.props;
+    const {map: _map, layerContainer: _lc, polylines, ...props} = this.props;
     this.leafletElement = multiPolyline(polylines, props);
   }
 

--- a/src/Polygon.js
+++ b/src/Polygon.js
@@ -14,7 +14,7 @@ export default class Polygon extends Path {
 
   componentWillMount() {
     super.componentWillMount();
-    const { map: _, positions, ...props } = this.props;
+    const { map: _map, layerContainer: _lc, positions, ...props } = this.props;
     this.leafletElement = polygon(positions, props);
   }
 

--- a/src/Polyline.js
+++ b/src/Polyline.js
@@ -10,7 +10,7 @@ export default class Polyline extends Path {
 
   componentWillMount() {
     super.componentWillMount();
-    const { map: _, positions, ...props } = this.props;
+    const { map: _map, layerContainer: _lc, positions, ...props } = this.props;
     this.leafletElement = polyline(positions, props);
   }
 

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -10,7 +10,7 @@ export default class Rectangle extends Path {
 
   componentWillMount() {
     super.componentWillMount();
-    const { bounds, map: _, ...props } = this.props;
+    const { bounds, map: _map, layerContainer: _lc, ...props } = this.props;
     this.leafletElement = rectangle(bounds, props);
   }
 

--- a/src/TileLayer.js
+++ b/src/TileLayer.js
@@ -10,7 +10,7 @@ export default class TileLayer extends BaseTileLayer {
 
   componentWillMount() {
     super.componentWillMount();
-    const { map: _, url, ...props } = this.props;
+    const { map: _map, layerContainer: _lc, url, ...props } = this.props;
     this.leafletElement = tileLayer(url, props);
   }
 

--- a/src/WMSTileLayer.js
+++ b/src/WMSTileLayer.js
@@ -10,7 +10,7 @@ export default class WMSTileLayer extends BaseTileLayer {
 
   componentWillMount() {
     super.componentWillMount();
-    const { map: _, url, ...props } = this.props;
+    const { map: _map, layerContainer: _lc, url, ...props } = this.props;
     this.leafletElement = tileLayer.wms(url, props);
   }
 }

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -2,3 +2,4 @@ export bounds from './bounds';
 export controlPosition from './controlPosition';
 export latlng from './latlng';
 export latlngList from './latlngList';
+export layerContainer from './layerContainer';

--- a/src/types/layerContainer.js
+++ b/src/types/layerContainer.js
@@ -1,0 +1,6 @@
+import { PropTypes } from 'react';
+
+export default PropTypes.shape({
+  addLayer: PropTypes.func.isRequired,
+  removeLayer: PropTypes.func.isRequired,
+});


### PR DESCRIPTION
**Edit (2016-04-02):**
Split the LayersControl code into a new branch, rebased to d057013, removed the built files, and filterd out the `layerContainer` prop everywhere from the layer options objects (same as the `map` prop).

~~This is a two-part PR.~~

**The first part is the `layerContainer` prop.**

Until now a `MapLayer` could receive either a `map` or a `layerGroup` prop. With this PR a `MapLayer` always receives both the `map` and the `layerContainer` props. The `map` is always the same, and the `layerContainer` is either the `map` or the old `layerGroup`.
This way all the map layers have access to the root `Map` instance, and other kind of layer containers can be introduced less intrusively.

~~**The second is a LayersControl implementation for #87** that makes use of the `layerContainer` prop.~~

~~This uses a HoC for the child layers, and acts as a layers container.~~
~~I haven't tested it thoroughly, but for my use case it seems to be working.~~
~~The readme includes an example.~~