### PR TITLE
LayersControl does not pass map props to children

### DIFF
--- a/__tests__/LayersControl.js
+++ b/__tests__/LayersControl.js
@@ -1,0 +1,40 @@
+import Leaflet from 'leaflet';
+import React from 'react';
+import { render } from 'react-dom';
+
+jest.autoMockOff();
+
+const LayersControl = require('../src/LayersControl').default;
+const Map = require('../src/Map').default;
+
+describe('LayersControl', () => {
+  it('passes its `map` prop to its children', () => {
+    document.body.innerHTML = '<div id="test"></div>';
+
+    class ChildComponent extends React.Component {
+      static propTypes = {
+        map: React.PropTypes.instanceOf(Leaflet.Map)
+      };
+
+      componentWillMount() {
+        expect(this.props.map).toBeDefined();
+      }
+
+      render() {
+        return null;
+      }
+    }
+
+    const component = (
+      <Map>
+        <LayersControl>
+          <LayersControl.Overlay checked name='test'>
+            <ChildComponent />
+          </LayersControl.Overlay>
+        </LayersControl>
+      </Map>
+    );
+
+    render(component, document.getElementById('test'));
+  });
+});

--- a/lib/LayersControl.js
+++ b/lib/LayersControl.js
@@ -89,7 +89,8 @@ var ControlledLayer = function (_Component) {
         layerContainer: {
           addLayer: this.addLayer.bind(this),
           removeLayer: this.removeLayer.bind(this)
-        }
+        },
+        map: this.props.map
       });
     }
   }]);

--- a/src/LayersControl.js
+++ b/src/LayersControl.js
@@ -43,6 +43,7 @@ class ControlledLayer extends Component {
         addLayer: ::this.addLayer,
         removeLayer: ::this.removeLayer,
       },
+      map: this.props.map,
     });
   }
 }


### PR DESCRIPTION
Map is not passed to children of LayersControl. This breaks the behaviour defined for custom components.

Could not get `unmock` to work properly and it always passed the test due to ChildComponent not being rendered. My failed attempt at unmock looked like this,

```js
jest.dontMock('../src/LayersControl');
jest.dontMock('../src/Map');
jest.dontMock('../src/MapControl');
jest.dontMock('../src/types/bounds');
jest.dontMock('../src/types/children');
jest.dontMock('../src/types/index');
jest.dontMock('../src/types/latlng');
jest.dontMock('../src/types/controlPosition');
jest.dontMock('../src/types/layerContainer');
```