### PR TITLE
when dynamically setting the size

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -64,6 +64,12 @@ export default class Map extends MapComponent {
     if (bounds && this.shouldUpdateBounds(bounds, prevProps.bounds)) {
       this.leafletElement.fitBounds(bounds, this.props.boundsOptions);
     }
+    if(this.props.style && prevProps.style){
+      if((this.props.style.width && prevProps.style.width && this.props.style.width !== prevProps.style.width)||
+        (this.props.style.height && prevProps.style.height && this.props.style.height !== prevProps.style.height)){
+          this.leafletElement.invalidateSize();
+      }     
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Hey, I am having a little problem when dynamically setting the size of the map. I think something like this should fix it. Basically when you change the size of the map `.invalidateSize()` should be called (according to Leaflet docs) so Leaflet reacts to the change. Otherwise I end up with half loaded tiles. I suggest something like this. What do you think?