### PR TITLE
Allow zero value for opacity and zIndex

### DIFF
--- a/src/BaseTileLayer.js
+++ b/src/BaseTileLayer.js
@@ -10,10 +10,10 @@ export default class BaseTileLayer extends MapLayer {
 
   componentDidUpdate(prevProps) {
     const { opacity, zIndex } = this.props;
-    if (opacity && opacity !== prevProps.opacity) {
+    if (typeof opacity === "number" && opacity !== prevProps.opacity) {
       this.leafletElement.setOpacity(opacity);
     }
-    if (zIndex && zIndex !== prevProps.zIndex) {
+    if (typeof zIndex === "number" && zIndex !== prevProps.zIndex) {
       this.leafletElement.setZIndex(zIndex);
     }
   }


### PR DESCRIPTION
`BaseTileLayer` currently doesn't accept an opacity of zero. This PR fixes the issue and lets it accept any number.