### PR TITLE
[leaflet 1.0] Change `removeFrom` to `remove` for `MapControl`

### DIFF
--- a/src/MapControl.js
+++ b/src/MapControl.js
@@ -26,7 +26,7 @@ export default class MapControl extends Component {
   }
 
   componentWillUnmount () {
-    this.leafletElement.removeFrom(this.context.map)
+    this.leafletElement.remove()
   }
 
   leafletElement: Object;


### PR DESCRIPTION
In Leaflet 1.0 `Control` doesn't have `removeFrom` anymore, only `remove`.