### PR TITLE
Updated MultiPolygon 'polygons' prop to allow polygons with holes

### DIFF
--- a/src/MultiPolygon.js
+++ b/src/MultiPolygon.js
@@ -8,7 +8,12 @@ import Path from './Path'
 
 export default class MultiPolygon extends Path {
   static propTypes = {
-    polygons: PropTypes.arrayOf(latlngListType).isRequired,
+    polygons: PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        latlngListType,
+        PropTypes.arrayOf(latlngListType),
+      ])
+    ).isRequired,
   };
 
   componentWillMount () {


### PR DESCRIPTION
Like 'Polygon' already allows passing array of arrays to make holes, also
MultiPolygon should allow it. Even though not read in Leaflet
MultiPolygon documentation, it supports it because Polygon supports it.