### PR TITLE
Update leaflet image path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,4 +33,4 @@ export const setIconDefaultImagePath = path => {
   Leaflet.Icon.Default.imagePath = path
 }
 
-setIconDefaultImagePath('//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images')
+setIconDefaultImagePath('//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.1/images/')


### PR DESCRIPTION
a `/` was missing at the end of the image path

I also updated the version to 1.0.1 (last version of leaflet)