### PR TITLE
Render Marker children inside div if necessary.

### DIFF
--- a/src/Marker.js
+++ b/src/Marker.js
@@ -54,6 +54,8 @@ export default class Marker extends MapLayer {
   }
 
   render (): null | React.Element<*> {
-    return this.props.children || null
+    return Array.isArray(this.props.children)
+      ? <div>{this.props.children}</div>
+      : (this.props.children || null)
   }
 }


### PR DESCRIPTION
I am passing an array of children into Marker, and I'm getting a runtime React error:

> Error: Marker.render(): A valid React element (or null) must be returned. You may have returned 
undefined, an array or some other invalid object.

I see you recently changed to use this code in a different place - I'd like to do the same thing here, also.

What do you think? Note that I didn't test this change yet - I'm looking for your comment first.