### PR TITLE
Only extract leaflet events for prop keys when callback exists

### DIFF
--- a/src/MapComponent.js
+++ b/src/MapComponent.js
@@ -42,7 +42,9 @@ export default class MapComponent extends Component<any, any, any> {
     return reduce(keys(props), (res, prop) => {
       if (EVENTS_RE.test(prop)) {
         const key = prop.replace(EVENTS_RE, (match, p) => p.toLowerCase())
-        res[ key ] = props[ prop ]
+        if (props[ prop ]) {
+          res[ key ] = props[ prop ]
+        }
       }
       return res
     }, {})


### PR DESCRIPTION
Fixes the following when `myCondition` is `falsey`.

`<MapComponent onClick={myCondition ? myCallback : null} />`