### PR TITLE
Allow ImageOverlay bounds to be changed on the fly

### DIFF
--- a/src/ImageOverlay.js
+++ b/src/ImageOverlay.js
@@ -39,5 +39,8 @@ export default class ImageOverlay extends MapLayer {
     if (toProps.opacity !== fromProps.opacity) {
       this.leafletElement.setOpacity(toProps.opacity)
     }
+    if (toProps.bounds !== fromProps.bounds) {
+      this.leafletElement.setBounds(L.latLngBounds(toProps.bounds))
+    }
   }
 }

--- a/src/ImageOverlay.js
+++ b/src/ImageOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { imageOverlay } from 'leaflet'
+import { imageOverlay, latLngBounds } from 'leaflet'
 import PropTypes from 'prop-types'
 
 import boundsType from './propTypes/bounds'
@@ -40,7 +40,7 @@ export default class ImageOverlay extends MapLayer {
       this.leafletElement.setOpacity(toProps.opacity)
     }
     if (toProps.bounds !== fromProps.bounds) {
-      this.leafletElement.setBounds(L.latLngBounds(toProps.bounds))
+      this.leafletElement.setBounds(latLngBounds(toProps.bounds))
     }
   }
 }


### PR DESCRIPTION
Looks like this was just an oversight.

The additional `latLngBounds` cast is necessary because the props can contain a 2-D Array, but `setBounds` expects a `Bounds` object with `_bounds.getNorthWest` etc.