### PR TITLE
Leaflet fires 'load' before handler is bound; use whenReady instead

### DIFF
--- a/src/MapComponent.js
+++ b/src/MapComponent.js
@@ -72,7 +72,10 @@ export default class MapComponent extends Component<any, any, any> {
     forEach(next, (cb, ev) => {
       if (!prev[ev] || cb !== prev[ev]) {
         diff[ev] = cb
-        el.on(ev, cb)
+        if (ev == 'load')
+          el.whenReady(cb);
+        else
+          el.on(ev, cb)
       }
     })
 


### PR DESCRIPTION
See #329 

One possible tweak might be to intercept the handler and add the "type" property to the argument, to be consistent with other handlers, but I haven't done this.