### PR TITLE
Add react-leaflet-sidebarv2 plugin to the list

### DIFF
--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -17,4 +17,5 @@ A non-exhaustive list of plugins adding functionalities to React-Leaflet. Please
 - [`react-leaflet-pane`](https://www.npmjs.com/package/react-leaflet-pane)
 - [`react-leaflet-shapefile`](https://www.npmjs.com/package/react-leaflet-shapefile)
 - [`react-leaflet-zoom-display`](https://www.npmjs.com/package/react-leaflet-zoom-display)
+- [`react-leaflet-sidebarv2`](https://www.npmjs.com/package/react-leaflet-sidebarv2)
 - [`react-mapbox-components`](https://www.npmjs.com/package/react-mapbox-components)


### PR DESCRIPTION
This is a plugin for https://github.com/nickpeihl/leaflet-sidebar-v2, which is a nice collapsable floating sidebar with tabs.  I originally attempted this by wrapping the original plugin, but it does a lot of DOM manipulation and was fundamentally at odds with React, at least how I envisaged it.  So, I render all the markup from scratch and just use the sidebar-v2 CSS, but that seems to work quite well.