### PR TITLE
Remove comma that causes a syntax error in node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - 8
+  - 6
 cache:
   yarn: true
   directories:

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,7 +41,8 @@ if (env === 'production') {
         dead_code: true,
         warnings: false,
       },
-    }),
+    // eslint-disable-next-line prettier/prettier
+    })
   )
 }
 


### PR DESCRIPTION
Fix #375

I added node 6 back to travis (this was the issue I disabled it for a while back). It is not actually necessary, but a lot of people are still using node 6, so this will prevent issues like #375.

I don’t know why `prettier/prettier` is asking for a comma there…