### PR TITLE
use https for tiles server

### DIFF
--- a/__tests__/Marker.js
+++ b/__tests__/Marker.js
@@ -13,7 +13,7 @@ describe('Marker', () => {
 
     renderIntoDocument(
       <Map center={position} zoom={10}>
-        <TileLayer url="http://{s}.tile.osm.org/{z}/{x}/{y}.png" />
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
         <Marker position={position} />
       </Map>,
     )

--- a/__tests__/Popup.js
+++ b/__tests__/Popup.js
@@ -14,7 +14,7 @@ describe('Popup', () => {
 
     renderIntoDocument(
       <Map center={position} zoom={10}>
-        <TileLayer url="http://{s}.tile.osm.org/{z}/{x}/{y}.png" />
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
         <Popup
           position={position}
           ref={function(e) {
@@ -72,7 +72,7 @@ describe('Popup', () => {
 
         return (
           <Map center={position} ref="map" zoom={10}>
-            <TileLayer url="http://{s}.tile.osm.org/{z}/{x}/{y}.png" />
+            <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
             {popup}
           </Map>
         )

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -329,13 +329,13 @@ Example usage:
   <LayersControl.BaseLayer name='OpenStreetMap.BlackAndWhite'>
     <TileLayer
       attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-      url='http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png'
+      url='https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png'
     />
   </LayersControl.BaseLayer>
   <LayersControl.BaseLayer name='OpenStreetMap.Mapnik'>
     <TileLayer
       attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-      url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
+      url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
     />
   </LayersControl.BaseLayer>
   <LayersControl.Overlay name='Marker with popup'>

--- a/docs/Getting started.md
+++ b/docs/Getting started.md
@@ -15,7 +15,7 @@ import L from 'leaflet';
 const position = [51.505, -0.09];
 const map = L.map('map').setView(position, 13);
 
-L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 }).addTo(map);
 
@@ -34,7 +34,7 @@ const position = [51.505, -0.09];
 const map = (
   <Map center={position} zoom={13}>
     <TileLayer
-      url='http://{s}.tile.osm.org/{z}/{x}/{y}.png'
+      url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
     />
     <Marker position={position}>

--- a/example/components/animate.js
+++ b/example/components/animate.js
@@ -49,7 +49,7 @@ export default class AnimateExample extends Component {
           zoom={13}>
           <TileLayer
             attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-            url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           />
           {marker}
         </Map>

--- a/example/components/bounds.js
+++ b/example/components/bounds.js
@@ -22,7 +22,7 @@ export default class BoundsExample extends Component {
       <Map bounds={this.state.bounds}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <Rectangle
           bounds={outer}

--- a/example/components/custom-component.js
+++ b/example/components/custom-component.js
@@ -49,7 +49,7 @@ export default class CustomComponent extends Component {
       <Map center={center} zoom={this.state.zoom}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <MyMarkersList markers={markers} />
       </Map>

--- a/example/components/draggable-marker.js
+++ b/example/components/draggable-marker.js
@@ -34,7 +34,7 @@ export default class DraggableExample extends Component {
       <Map center={position} zoom={this.state.zoom}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <Marker
           draggable={this.state.draggable}

--- a/example/components/events.js
+++ b/example/components/events.js
@@ -40,7 +40,7 @@ export default class EventsExample extends Component {
         zoom={13}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         {marker}
       </Map>

--- a/example/components/layers-control.js
+++ b/example/components/layers-control.js
@@ -23,13 +23,13 @@ export default class LayersControlExample extends Component {
           <BaseLayer checked name="OpenStreetMap.Mapnik">
             <TileLayer
               attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-              url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
           </BaseLayer>
           <BaseLayer name="OpenStreetMap.BlackAndWhite">
             <TileLayer
               attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-              url="http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png"
+              url="https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png"
             />
           </BaseLayer>
           <Overlay name="Marker with popup">

--- a/example/components/other-layers.js
+++ b/example/components/other-layers.js
@@ -18,7 +18,7 @@ export default class OtherLayersExample extends Component {
       <Map center={center} zoom={13}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <LayerGroup>
           <Circle center={center} fillColor="blue" radius={200} />

--- a/example/components/pane.js
+++ b/example/components/pane.js
@@ -26,7 +26,7 @@ export default class PaneExample extends Component {
       <Map bounds={outer}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         {this.state.render ? (
           <Pane name="cyan-rectangle" style={{ zIndex: 500 }}>

--- a/example/components/simple.js
+++ b/example/components/simple.js
@@ -14,7 +14,7 @@ export default class SimpleExample extends Component {
       <Map center={position} zoom={this.state.zoom}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <Marker position={position}>
           <Popup>

--- a/example/components/tooltip.js
+++ b/example/components/tooltip.js
@@ -39,7 +39,7 @@ export default class TooltipExample extends Component {
       <Map center={center} zoom={13}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <Circle
           center={center}

--- a/example/components/vector-layers.js
+++ b/example/components/vector-layers.js
@@ -34,7 +34,7 @@ export default class VectorLayersExample extends Component {
       <Map center={center} zoom={13}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <Circle center={center} fillColor="blue" radius={200} />
         <CircleMarker center={[51.51, -0.12]} color="red" radius={20}>

--- a/example/components/video-overlay.js
+++ b/example/components/video-overlay.js
@@ -15,7 +15,7 @@ export default class VideoOverlayExample extends Component {
       <Map center={[25, -100]} onClick={this.onTogglePlay} zoom={4}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <VideoOverlay
           bounds={[[32, -130], [13, -100]]}

--- a/example/components/viewport.js
+++ b/example/components/viewport.js
@@ -27,7 +27,7 @@ export default class ViewportExample extends Component {
         viewport={this.state.viewport}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
       </Map>
     )

--- a/example/components/wms-tile-layer.js
+++ b/example/components/wms-tile-layer.js
@@ -23,7 +23,7 @@ export default class WMSTileLayerExample extends Component {
         onClick={this.onClick}>
         <TileLayer
           attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <WMSTileLayer
           layers={this.state.bluemarble ? 'nasa:bluemarble' : 'ne:ne'}

--- a/example/components/zoom-control.js
+++ b/example/components/zoom-control.js
@@ -5,7 +5,7 @@ const ZoomControlExample = () => (
   <Map center={[51.505, -0.09]} zoom={13} zoomControl={false}>
     <TileLayer
       attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-      url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+      url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <ZoomControl position="topright" />
   </Map>

--- a/example/umd.html
+++ b/example/umd.html
@@ -32,7 +32,7 @@ const Example = () => (
   <Map center={position} zoom={13}>
     <TileLayer
       attribution="&copy; <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-      url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+      url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Marker position={position}>
       <Popup>


### PR DESCRIPTION
Using the Geolocation API in current browsers requires a secure context [0].
I updated the documentation and examples to load the map tiles over secure connections, to prevent possible problems.


[0]https://developer.mozilla.org/en-US/docs/Web/API/Geolocation