### PR TITLE
Don't remove zIndex/opacity from initial WMS props

### DIFF
--- a/src/WMSTileLayer.js
+++ b/src/WMSTileLayer.js
@@ -21,7 +21,7 @@ export default class WMSTileLayer extends GridLayer<LeafletElement, Props> {
   }
 
   createLeafletElement(props: Props): LeafletElement {
-    const { url, opacity: _o, zIndex: _z, ...params } = props
+    const { url, ...params } = props
     return new TileLayer.WMS(url, this.getOptions(params))
   }
 


### PR DESCRIPTION
See PaulLecam/react-leaflet#404.  Initial values were being removed
from the parameters passed to the leaflet element when it was first
created; later updates were still correctly applied.