### PR TITLE
Add types to satisfy flow 59

### DIFF
--- a/src/LayersControl.js
+++ b/src/LayersControl.js
@@ -102,7 +102,7 @@ class ControlledLayer extends Component<ControlledLayerProps> {
 class BaseLayer extends ControlledLayer {
   static propTypes = controlledLayerPropTypes
 
-  addLayer(layer) {
+  addLayer(layer: Layer) {
     this.layer = layer // Keep layer reference to handle dynamic changes of props
     const { addBaseLayer, checked, name } = this.props
     addBaseLayer(layer, name, checked)
@@ -112,7 +112,7 @@ class BaseLayer extends ControlledLayer {
 class Overlay extends ControlledLayer {
   static propTypes = controlledLayerPropTypes
 
-  addLayer(layer) {
+  addLayer(layer: Layer) {
     this.layer = layer // Keep layer reference to handle dynamic changes of props
     const { addOverlay, checked, name } = this.props
     addOverlay(layer, name, checked)


### PR DESCRIPTION
Upgrading to flow-bin@0.59.0 yields the following errors:

```
$ flow
Error: src/LayersControl.js:105
105:   addLayer(layer) {
                ^^^^^ parameter `layer`. Missing annotation

Error: src/LayersControl.js:115
115:   addLayer(layer) {
                ^^^^^ parameter `layer`. Missing annotation
```

This commit adds some missing annotations, satisfying the beast.