### PR TITLE
🚧 Fix - remove tooltip when interactive

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -70,9 +70,8 @@ export default class Tooltip extends MapComponent<LeafletElement, Props> {
       tooltipopen: this.onTooltipOpen,
       tooltipclose: this.onTooltipClose,
     })
-    if (this.props.interactive !== true) {
-      popupContainer.unbindTooltip(this.leafletElement)
-    }
+
+    popupContainer.unbindTooltip(this.leafletElement)
 
     super.componentWillUnmount()
   }


### PR DESCRIPTION
## Overview
If you create a `<Tooltip>` component which passes the `interactive` and `permanent` props as true, when the component is unmounted it never removes the tooltip from the map. Currently, the code only unbinds the tooltip if `interactive` is not true.

When the parent component's `componentWillUnmount` function is called it simply [removes](https://github.com/PaulLeCam/react-leaflet/blob/master/src/MapComponent.js#L39#L46) the event handlers. 

To give you an example of how I've implemented the functionality and been able to spot the bug please see below: 

```js
return (
  <CircleMarker
    center={center}
    key={key}
    onClick={() => onNodeClick(id)}
    onContextmenu={() => !activeNodeId && setActiveTooltipId(id)}
    pane="markerPane"
    {...options}
  >
    {hasActiveTooltip && (
      <Tooltip
        direction="right"
        interactive
        offset={[20, 0]}
        opacity={1}
        permanent
      >
        <ConnectedNodesList
          addEdge={addEdge}
          removeEdge={removeEdge}
          data={connectedNodeData}
          setActiveEdgeId={setActiveEdgeId}
        />
      </Tooltip>
    )}
  </CircleMarker>
)
```

I spotted that the condition was added to the following [commit](https://github.com/jonathanchrisp/react-leaflet/commit/c625c83a15fecf9a83f63c05a0064cdd288c72d6). If possible can you let me know why this was added? Did this fix a previous bug?

## Example 
![tooltip-present](https://user-images.githubusercontent.com/406799/36363310-1ccbb924-1590-11e8-8321-1a563f82d304.gif)