### PR TITLE
Add types to satisfy flow-bin 0.66

### DIFF
--- a/src/FeatureGroup.js
+++ b/src/FeatureGroup.js
@@ -16,7 +16,7 @@ type ChildContext = {
 }
 
 export default class FeatureGroup extends Path<LeafletElement, Props> {
-  static childContextTypes = {
+  static childContextTypes: Object = {
     children: children,
     layerContainer: layerContainer,
     popupContainer: layer,

--- a/src/LayersControl.js
+++ b/src/LayersControl.js
@@ -139,7 +139,7 @@ export default class LayersControl extends MapControl<
     position: controlPosition,
   }
 
-  static contextTypes = {
+  static contextTypes: Object = {
     layerContainer: layerContainer,
     map: map,
   }


### PR DESCRIPTION
Upgrading to flow-bin@0.66.0 yields the following errors:

```> flow check

Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/FeatureGroup.js:19:30

Could not decide which case to select. Since case 1 [1] may work but if it
doesn't case 5 [2] looks promising too. To fix add a type annotation to
children [3] or to layer [4].

     src/FeatureGroup.js
     16│ }
     17│
     18│ export default class FeatureGroup extends Path<LeafletElement, Props> {
     19│   static childContextTypes = {
 [3] 20│     children: children,
     21│     layerContainer: layerContainer,
 [4] 22│     popupContainer: layer,
     23│   }
     24│
     25│   getChildContext(): ChildContext {
     26│     return {

     /private/tmp/flow/flowlib_493edf3/react.js
 [2] 74│   static childContextTypes: any;

     src/Path.js
 [1] 38│   static childContextTypes = {
     39│     children: children,
     40│     popupContainer: layer,
     41│   }


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/LayersControl.js:142:25

Could not decide which case to select. Since case 1 [1] may work but if it
doesn't case 5 [2] looks promising too. To fix add a type annotation to map [3].

     src/LayersControl.js
     139│     position: controlPosition,
     140│   }
     141│
     142│   static contextTypes = {
     143│     layerContainer: layerContainer,
 [3] 144│     map: map,
     145│   }
     146│
     147│   controlProps: {
     148│     addBaseLayer: AddLayerHandler,

     /private/tmp/flow/flowlib_493edf3/react.js
 [2]  75│   static contextTypes: any;

     src/MapControl.js
 [1]  18│   static contextTypes = {
      19│     map: map,
      20│   }



Found 2 errors
```

This commit fix that.