### PR TITLE
🚧 Fix - added es folder to files array in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/PaulLeCam/react-leaflet/issues"
   },
   "homepage": "https://github.com/PaulLeCam/react-leaflet",
-  "files": [".babelrc", "dist/*", "lib/*", "src/*"],
+  "files": [".babelrc", "dist/*", "es/*", "lib/*", "src/*"],
   "dependencies": {
     "lodash": "^4.0.0",
     "lodash-es": "^4.0.0",


### PR DESCRIPTION
## Updated
Following the latest version, I've been getting import unresolved errors when running eslint locally. 

```
error  Unable to resolve path to module 'react-leaflet'  import/no-unresolved
```

After checking `node_modules` I noticed that the `es` folder is being cleared out on publish. I've simply added this to the files array.
