### PR TITLE
Remove event listeners

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -273,6 +273,9 @@ export default class Map extends MapComponent<LeafletElement, Props> {
     super.componentWillUnmount()
     // The canvas renderer uses requestAnimationFrame, making a deferred call to a deleted object
     // When preferCanvas is set, use simpler teardown logic
+    this.leafletElement.off('move', this.onViewportChange);
+    this.leafletElement.off('moveend', this.onViewportChanged);
+
     if (this.props.preferCanvas === true) {
       this.leafletElement._initEvents(true)
       this.leafletElement._stop()

--- a/src/Map.js
+++ b/src/Map.js
@@ -271,11 +271,12 @@ export default class Map extends MapComponent<LeafletElement, Props> {
 
   componentWillUnmount() {
     super.componentWillUnmount()
+
+    this.leafletElement.off('move', this.onViewportChange)
+    this.leafletElement.off('moveend', this.onViewportChanged)
+
     // The canvas renderer uses requestAnimationFrame, making a deferred call to a deleted object
     // When preferCanvas is set, use simpler teardown logic
-    this.leafletElement.off('move', this.onViewportChange);
-    this.leafletElement.off('moveend', this.onViewportChanged);
-
     if (this.props.preferCanvas === true) {
       this.leafletElement._initEvents(true)
       this.leafletElement._stop()


### PR DESCRIPTION
This prevents an infinite loop error that I experienced on my React app, apparently the events were being fired even after the DOM element was removed