### PR TITLE
Checking if popup is open in onRender

### DIFF
--- a/src/Popup.js
+++ b/src/Popup.js
@@ -103,7 +103,7 @@ export default class Popup extends DivOverlay<LeafletElement, Props> {
   }
 
   onRender = () => {
-    if (this.props.autoPan !== false) {
+    if (this.props.autoPan !== false && this.leafletElement.isOpen()) {
       if (this.leafletElement._map && this.leafletElement._map._panAnim) {
         this.leafletElement._map._panAnim = undefined
       }


### PR DESCRIPTION
I am using react-leaflet together with my own react-implementation of leaflet markercluster. The following error can occurr (see stack trace below).
1.	I have a popup open for a marker
2.	The content of the popup is changed at the same time as the position of the marker is changed.
3.	The position change results in that the marker gets clustered with another marker and the popup gets closed by leaflet-markercluster.
4.	Since the content of the popup is changed, the callback function supplied to the render call in DivOverlay's renderContent and then Popup's onRender is executed.
5.	this.leafletElement._adjustPan() is called but since the popup no longer exists on the map an error is thrown in the leaflet marker code.

I have added a check if the popup is open on the map in the onRender function
