### PR TITLE
Fixed attributions not being updated when props change.

### DIFF
--- a/src/TileLayer.js
+++ b/src/TileLayer.js
@@ -18,7 +18,14 @@ class TileLayer extends GridLayer<LeafletElement, Props> {
     super.updateLeafletElement(fromProps, toProps)
     if (toProps.url !== fromProps.url) {
       this.leafletElement.setUrl(toProps.url)
-    }
+	}
+
+	if(toProps.attribution !== fromProps.attribution) {
+		const map = toProps.leaflet.map;
+
+		map.attributionControl.removeAttribution(fromProps.attribution);
+		map.attributionControl.addAttribution(toProps.attribution);
+	}
   }
 }
 


### PR DESCRIPTION
When changing a TileLayer's attribution prop, it was not updating the DOM. This implements a fix using the Leaflet API as documented [here](https://leafletjs.com/reference-1.3.4.html#control-attribution-addattribution).