### PR TITLE
Inform about missing context element

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -10,7 +10,7 @@ open pull requests to update this list!
 
 | Plugin                                                                                                           | Compatible with v2 |
 | ---------------------------------------------------------------------------------------------------------------- | ------------------ |
-| [`react-leaflet-ant-path`](https://www.npmjs.com/package/react-leaflet-ant-path)                                 | unknown            |
+| [`react-leaflet-ant-path`](https://www.npmjs.com/package/react-leaflet-ant-path)                                 | **yes**            |
 | [`react-leaflet-bing`](https://www.npmjs.com/package/react-leaflet-bing)                                         | unknown            |
 | [`react-leaflet-choropleth`](https://www.npmjs.com/package/react-leaflet-choropleth)                             | unknown            |
 | [`react-leaflet-cluster-layer`](https://www.npmjs.com/package/react-leaflet-cluster-layer)                       | unknown            |

--- a/src/MapLayer.js
+++ b/src/MapLayer.js
@@ -19,7 +19,12 @@ export default class MapLayer<
   }
 
   get layerContainer(): Layer {
-    return this.props.leaflet.layerContainer || this.props.leaflet.map
+    const { leaflet } = this.props;
+    if(!leaflet) {
+      throw new Error("Can't find leaflet on context. Please wrap you component using 'withLeaflet' HOC")
+    }
+    
+    return leaflet.layerContainer || leaflet.map
   }
 
   createLeafletElement(_props: Props): LeafletElement {


### PR DESCRIPTION
When creating a custom component if it use some class that directly/indirectly extends MapLayer, it will fail if not using withLeaflet HOC (missing leaflet inside its context).
The error doesn't point out to it, I'm throwing a custom error whenever it's missing the leaflet on context, informing about the use of the HOC.

Also, to added the info about the support of my plugin for the v2 👍 