### PR TITLE
Add react-leaflet-wmts to plugins page

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -43,4 +43,4 @@ open pull requests to update this list!
 | [`react-leaflet-zoom-indicator`](https://www.npmjs.com/package/react-leaflet-zoom-indicator)                     | unknown            |
 | [`react-mapbox-components`](https://www.npmjs.com/package/react-mapbox-components)                               | unknown            |
 | [`react-leaflet-sidetabs`](https://www.npmjs.com/package/react-leaflet-sidetabs)                               | **yes**            |
-| [`react-leaflet-wmts`](https://www.npmjs.com/package/react-leaflet-wmts)                             | unknown            |
+| [`react-leaflet-wmts`](https://www.npmjs.com/package/react-leaflet-wmts)                             | **yes**            |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -43,3 +43,4 @@ open pull requests to update this list!
 | [`react-leaflet-zoom-indicator`](https://www.npmjs.com/package/react-leaflet-zoom-indicator)                     | unknown            |
 | [`react-mapbox-components`](https://www.npmjs.com/package/react-mapbox-components)                               | unknown            |
 | [`react-leaflet-sidetabs`](https://www.npmjs.com/package/react-leaflet-sidetabs)                               | **yes**            |
+| [`react-leaflet-wmts`](https://www.npmjs.com/package/react-leaflet-wmts)                             | unknown            |


### PR DESCRIPTION
I've built a plugin that wraps https://github.com/mylen/leaflet.TileLayer.WMTS behaviour. I think it could be useful to have in the plugins page.

Thanks for react-leaflet by the way!