### PR TITLE
Updates third party compatibility docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -21,7 +21,7 @@ open pull requests to update this list!
 | [`react-leaflet-deflate`](https://www.npmjs.com/package/react-leaflet-deflate)                                   | unknown            |
 | [`react-leaflet-distance-marker`](https://www.npmjs.com/package/react-leaflet-distance-marker)                   | unknown            |
 | [`react-leaflet-distortable-imageoverlay`](https://www.npmjs.com/package/react-leaflet-distortable-imageoverlay) | **yes**            |
-| [`react-leaflet-div-icon`](https://www.npmjs.com/package/react-leaflet-div-icon)                                 | unknown            |
+| [`react-leaflet-div-icon`](https://www.npmjs.com/package/react-leaflet-div-icon)                                 | **no**            |
 | [`react-leaflet-draggable-polyline`](https://www.npmjs.com/package/react-leaflet-draggable-polyline)             | unknown            |
 | [`react-leaflet-draw`](https://www.npmjs.com/package/react-leaflet-draw)                                         | unknown            |
 | [`react-leaflet-easyprint`](https://www.npmjs.com/package/react-leaflet-easyprint)                               | unknown            |
@@ -31,7 +31,7 @@ open pull requests to update this list!
 | [`react-leaflet-geojson-cluster`](https://www.npmjs.com/package/react-leaflet-geojson-cluster)                   | unknown            |
 | [`react-leaflet-geojson-patterns`](https://www.npmjs.com/package/react-leaflet-geojson-patterns)                 | **yes**            |
 | [`react-leaflet-google`](https://www.npmjs.com/package/react-leaflet-google)                                     | **yes**            |
-| [`react-leaflet-heatmap-layer`](https://www.npmjs.com/package/react-leaflet-heatmap-layer)                       | unknown            |
+| [`react-leaflet-heatmap-layer`](https://www.npmjs.com/package/react-leaflet-heatmap-layer)                       | **yes**            |
 | [`react-leaflet-locate-control`](https://www.npmjs.com/package/react-leaflet-locate-control)                     | **no**             |
 | [`react-leaflet-markercluster`](https://www.npmjs.com/package/react-leaflet-markercluster)                       | unknown            |
 | [`react-leaflet-marker-layer`](https://www.npmjs.com/package/react-leaflet-marker-layer)                         | unknown            |


### PR DESCRIPTION
I was facing some issues while trying to use react-leaflet-div-icon and react-leaflet-heatmap-layer with react-leaflet, and then I realized that react-leaflet-div-icon [doesn't support react-leaflet v2.0](https://github.com/jgimbel/react-leaflet-div-icon/issues/20) and [react-leaflet-heatmap-layer does](https://github.com/OpenGov/react-leaflet-heatmap-layer/blob/master/CHANGELOG.md#200-release).