### PR TITLE
Passing LayerGroup options to the correct leaflet LayerGroup parameter

### DIFF
--- a/src/LayerGroup.js
+++ b/src/LayerGroup.js
@@ -11,7 +11,7 @@ type Props = MapLayerProps
 
 class LayerGroup extends MapLayer<LeafletElement, Props> {
   createLeafletElement(props: Props): LeafletElement {
-    const el = new LeafletLayerGroup(this.getOptions(props))
+    const el = new LeafletLayerGroup([], this.getOptions(props))
     this.contextValue = { ...props.leaflet, layerContainer: el }
     return el
   }


### PR DESCRIPTION
While working with react-leaflet LayerGroup, I noticed that the annotations were not being passed correctly to the underlying Leaflet LayerGroup.  

None of the options were being passed through correctly, as they're being passed in as the layers instead of the options.