### PR TITLE
'useLeaflet' hook

### DIFF
--- a/docs/custom-components.md
+++ b/docs/custom-components.md
@@ -11,6 +11,8 @@ If these plugins do not match your needs, adding layers and behaviors provided b
 - `createLeafletElement (props: Object): Object` (mandatory): create and return the relevant Leaflet element instance. this instance will be stored in the class as `this.leafletElement` and used by other methods handling behavior such as events bindings.
 - `updateLeafletElement (fromProps: Object, toProps: Object): Object` (optional): use this method to update the `leafletElement` according to the properties changes.
 
+To access [Leaflet context object](context.md) in your custom functional component the `useLeaflet()` [hook](hooks.md) can be used.
+
 By wrapping your custom component using the `withLeaflet()` higher-order component, it will get the [Leaflet context object](context.md) injected in its props.
 
 Make sure to read the [introduction page](intro.md) of this documentation to understand what your custom component should use and eventually provide, and check the [class hierarchy](class-hierarchy.md) to see what class to extend.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,19 @@
+---
+id: hooks
+title: Hooks
+---
+
+Starting with version 2.2.2, React-Leaflet leverages the new [Hooks API](https://reactjs.org/docs/hooks-intro.html) introduced in React v16.8.
+
+The `useLeaflet()` hook returns Object of the following Flow type:
+
+```javascript
+type LeafletContext = {
+  map?: Map,
+  pane?: ?string,
+  layerContainer?: ?LayerContainer,
+  popupContainer?: ?Layer,
+}
+```
+
+The same type is returned by the leaflet [context](context.md).

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "peerDependencies": {
     "leaflet": "^1.4.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^16.8.2",
+    "react-dom": "^16.8.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/context.js
+++ b/src/context.js
@@ -10,12 +10,12 @@ import React, {
 
 import type { LeafletContext } from './types'
 
-const Context = createContext<LeafletContext>({})
+const leafletContext = createContext<LeafletContext>({})
 
-export const useLeaflet = (): LeafletContext => useContext(Context)
+export const useLeaflet = (): LeafletContext => useContext(leafletContext)
 
-export const LeafletConsumer = Context.Consumer
-export const LeafletProvider = Context.Provider
+export const LeafletConsumer = leafletContext.Consumer
+export const LeafletProvider = leafletContext.Provider
 
 export const withLeaflet = <Config: { leaflet: LeafletContext }, Instance>(
   WrappedComponent: AbstractComponent<Config, Instance>,

--- a/src/context.js
+++ b/src/context.js
@@ -1,24 +1,31 @@
 // @flow
 
 import hoistNonReactStatics from 'hoist-non-react-statics'
-import React, { createContext, forwardRef, type AbstractComponent } from 'react'
+import React, {
+  createContext,
+  forwardRef,
+  useContext,
+  type AbstractComponent,
+} from 'react'
 
 import type { LeafletContext } from './types'
 
-const { Consumer, Provider } = createContext<LeafletContext>({})
+const Context = createContext<LeafletContext>({})
 
-export const LeafletConsumer = Consumer
-export const LeafletProvider = Provider
+export const useLeaflet = () => useContext(Context)
+
+export const LeafletConsumer = Context.Consumer
+export const LeafletProvider = Context.Provider
 
 export const withLeaflet = <Config: { leaflet: LeafletContext }, Instance>(
   WrappedComponent: AbstractComponent<Config, Instance>,
 ): AbstractComponent<$Diff<Config, { leaflet: LeafletContext }>, Instance> => {
   const WithLeafletComponent = (props, ref) => (
-    <Consumer>
+    <LeafletConsumer>
       {(leaflet: LeafletContext) => (
         <WrappedComponent {...props} leaflet={leaflet} ref={ref} />
       )}
-    </Consumer>
+    </LeafletConsumer>
   )
 
   const name = // flowlint-next-line sketchy-null-string:off

--- a/src/context.js
+++ b/src/context.js
@@ -12,7 +12,7 @@ import type { LeafletContext } from './types'
 
 const Context = createContext<LeafletContext>({})
 
-export const useLeaflet = () => useContext(Context)
+export const useLeaflet = (): LeafletContext => useContext(Context)
 
 export const LeafletConsumer = Context.Consumer
 export const LeafletProvider = Context.Provider

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 // @flow
 
-export { LeafletConsumer, LeafletProvider, withLeaflet } from './context'
+export {
+  LeafletConsumer,
+  LeafletProvider,
+  withLeaflet,
+  useLeaflet,
+} from './context'
 
 export type {
   LeafletContext,

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Getting started": ["intro", "setup", "installation", "examples"],
-    "API": ["context", "events", "components"],
+    "API": ["hooks", "context", "events", "components"],
     "Guides": ["custom-components", "class-hierarchy"],
     "Extra": ["plugins"]
   }


### PR DESCRIPTION
Implemented `useLeaflet` hook.

Example:
```javascript
const MyComponent = (props) => {
  const { map } = useLeaflet()
  return <>...</>
}
```

closes #539 