### PR TITLE
Draggable Marker example property name fix up.

### DIFF
--- a/example/components/draggable-marker.js
+++ b/example/components/draggable-marker.js
@@ -53,7 +53,7 @@ export default class DraggableExample extends Component<{}, State> {
         />
         <Marker
           draggable={this.state.draggable}
-          onDragend={this.updatePosition}
+          ondragend={this.updatePosition}
           position={markerPosition}
           ref={this.refmarker}>
           <Popup minWidth={90}>


### PR DESCRIPTION
Hi all

I've fixed a naming mistake on event name property in the Draggable Marker example.

onDragend doesn't exist on MarkerEvents it's ondragend. :)

Cheers
Dan