### PR TITLE
fix circlemarker by updating equality check

### DIFF
--- a/src/CircleMarker.js
+++ b/src/CircleMarker.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { CircleMarker as LeafletCircleMarker } from 'leaflet'
+import { CircleMarker as LeafletCircleMarker, latLng } from 'leaflet'
 
 import { withLeaflet } from './context'
 import Path from './Path'
@@ -20,7 +20,7 @@ class CircleMarker extends Path<LeafletElement, Props> {
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props) {
-    if (toProps.center !== fromProps.center) {
+    if (!latLng(toProps.center).equals(fromProps.center)) {
       this.leafletElement.setLatLng(toProps.center)
     }
     if (toProps.radius !== fromProps.radius) {


### PR DESCRIPTION
After a 2 years old discussion about this [issue](https://github.com/YUzhva/react-leaflet-markercluster/issues/31) which tracks back to your repository, i propose a little fix that makes a lot of lifes easier.

The base of the fix lies in the CircleMarker.js file, which until now, made it impossible to render Circlemarkers inside of [react-leaflet-markercluster](https://github.com/YUzhva/react-leaflet-markercluster) without throwing:
> TypeError: Cannot read property 'lat' of undefined. 

This fix changes the equality check for the updateLeafletElement center property.

`- if (toProps.center !== fromProps.center) `
`+ if (!latLng(toProps.center).equals(fromProps.center))`
