### PR TITLE
use deep comparison for Marker position

### DIFF
--- a/src/Marker.js
+++ b/src/Marker.js
@@ -24,7 +24,7 @@ class Marker extends MapLayer<LeafletElement, Props> {
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props) {
-    if (toProps.position !== fromProps.position) {
+    if (toProps.position[0] !== fromProps.position[0] || toProps.position[1] !== fromProps.position[1]) {
       this.leafletElement.setLatLng(toProps.position)
     }
     if (toProps.icon !== fromProps.icon) {


### PR DESCRIPTION
Comparing the position array by reference leads to unnecessary updating of the Marker. This leads to very slow performance when there are many markers. I believe this partially fixes https://github.com/YUzhva/react-leaflet-markercluster/issues/78.

Is there some reason this is not the default method of comparison?