### PR TITLE
Avoid useless and issue-prone re-renderings because of shallow props objects comparisons

### DIFF
--- a/src/Circle.js
+++ b/src/Circle.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { Circle as LeafletCircle } from 'leaflet'
+import isEqual from 'fast-deep-equal'
 
 import { withLeaflet } from './context'
 import Path from './Path'
@@ -21,7 +22,7 @@ class Circle extends Path<LeafletElement, Props> {
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props) {
-    if (toProps.center !== fromProps.center) {
+    if (!isEqual(toProps.center, fromProps.center)) {
       this.leafletElement.setLatLng(toProps.center)
     }
     if (toProps.radius !== fromProps.radius) {

--- a/src/CircleMarker.js
+++ b/src/CircleMarker.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { CircleMarker as LeafletCircleMarker } from 'leaflet'
+import isEqual from 'fast-deep-equal'
 
 import { withLeaflet } from './context'
 import Path from './Path'
@@ -20,7 +21,7 @@ class CircleMarker extends Path<LeafletElement, Props> {
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props) {
-    if (toProps.center !== fromProps.center) {
+    if (!isEqual(toProps.center, fromProps.center)) {
       this.leafletElement.setLatLng(toProps.center)
     }
     if (toProps.radius !== fromProps.radius) {

--- a/src/ImageOverlay.js
+++ b/src/ImageOverlay.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { ImageOverlay as LeafletImageOverlay, latLngBounds } from 'leaflet'
+import isEqual from 'fast-deep-equal'
 
 import { withLeaflet } from './context'
 import MapLayer from './MapLayer'
@@ -30,7 +31,7 @@ class ImageOverlay extends MapLayer<LeafletElement, Props> {
     if (toProps.url !== fromProps.url) {
       this.leafletElement.setUrl(toProps.url)
     }
-    if (toProps.bounds !== fromProps.bounds) {
+    if (!isEqual(toProps.bounds, fromProps.bounds)) {
       this.leafletElement.setBounds(latLngBounds(toProps.bounds))
     }
     if (toProps.opacity !== fromProps.opacity) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -7,6 +7,7 @@ import {
   type Renderer,
 } from 'leaflet'
 import React, { type Node } from 'react'
+import isEqual from 'fast-deep-equal'
 
 import { LeafletProvider } from './context'
 import MapEvented from './MapEvented'
@@ -151,7 +152,7 @@ export default class Map extends MapEvented<LeafletElement, Props> {
 
     updateClassName(this.container, fromProps.className, className)
 
-    if (viewport && viewport !== fromProps.viewport) {
+    if (viewport && !isEqual(viewport, fromProps.viewport)) {
       const c = viewport.center ? viewport.center : center
       const z = viewport.zoom == null ? zoom : viewport.zoom
       if (useFlyTo === true) {
@@ -188,7 +189,7 @@ export default class Map extends MapEvented<LeafletElement, Props> {
     if (
       bounds &&
       (this.shouldUpdateBounds(bounds, fromProps.bounds) ||
-        boundsOptions !== fromProps.boundsOptions)
+        !isEqual(boundsOptions, fromProps.boundsOptions))
     ) {
       if (useFlyTo === true) {
         this.leafletElement.flyToBounds(
@@ -200,7 +201,7 @@ export default class Map extends MapEvented<LeafletElement, Props> {
       }
     }
 
-    if (boxZoom !== fromProps.boxZoom) {
+    if (!isEqual(boxZoom, fromProps.boxZoom)) {
       if (boxZoom === true) {
         this.leafletElement.boxZoom.enable()
       } else {
@@ -355,7 +356,7 @@ export default class Map extends MapEvented<LeafletElement, Props> {
     if (!prev) return true
     next = normalizeCenter(next)
     prev = normalizeCenter(prev)
-    return next[0] !== prev[0] || next[1] !== prev[1]
+    return !isEqual(next[0], prev[0]) || !isEqual(next[1], prev[1])
   }
 
   shouldUpdateBounds(next: LatLngBounds, prev: LatLngBounds) {

--- a/src/MapControl.js
+++ b/src/MapControl.js
@@ -2,6 +2,7 @@
 
 import { Control } from 'leaflet'
 import { Component } from 'react'
+import isEqual from 'fast-deep-equal'
 
 import type { MapControlProps } from './types'
 
@@ -21,7 +22,7 @@ export default class MapControl<
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props): void {
-    if (toProps.position !== fromProps.position) {
+    if (!isEqual(toProps.position, fromProps.position)) {
       this.leafletElement.setPosition(toProps.position)
     }
   }

--- a/src/MapEvented.js
+++ b/src/MapEvented.js
@@ -2,6 +2,7 @@
 
 import type { Evented } from 'leaflet'
 import { Component } from 'react'
+import isEqual from 'fast-deep-equal'
 
 export const EVENTS_RE = /^on(.+)$/i
 
@@ -61,14 +62,14 @@ export default class MapEvented<
 
     const diff = { ...prev }
     Object.keys(prev).forEach(ev => {
-      if (next[ev] == null || prev[ev] !== next[ev]) {
+      if (next[ev] == null || !isEqual(prev[ev], next[ev])) {
         delete diff[ev]
         el.off(ev, prev[ev])
       }
     })
 
     Object.keys(next).forEach(ev => {
-      if (prev[ev] == null || next[ev] !== prev[ev]) {
+      if (prev[ev] == null || !isEqual(next[ev], prev[ev])) {
         diff[ev] = next[ev]
         el.on(ev, next[ev])
       }

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -2,6 +2,7 @@
 
 import { type Icon, Marker as LeafletMarker } from 'leaflet'
 import React from 'react'
+import isEqual from 'fast-deep-equal'
 
 import { LeafletProvider, withLeaflet } from './context'
 import MapLayer from './MapLayer'
@@ -24,10 +25,10 @@ class Marker extends MapLayer<LeafletElement, Props> {
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props) {
-    if (toProps.position !== fromProps.position) {
+    if (!isEqual(toProps.position, fromProps.position)) {
       this.leafletElement.setLatLng(toProps.position)
     }
-    if (toProps.icon !== fromProps.icon) {
+    if (!isEqual(toProps.icon, fromProps.icon)) {
       this.leafletElement.setIcon(toProps.icon)
     }
     if (toProps.zIndexOffset !== fromProps.zIndexOffset) {

--- a/src/Polygon.js
+++ b/src/Polygon.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { Polygon as LeafletPolygon } from 'leaflet'
+import isEqual from 'fast-deep-equal'
 
 import { withLeaflet } from './context'
 import Path from './Path'
@@ -17,7 +18,7 @@ class Polygon extends Path<LeafletElement, Props> {
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props) {
-    if (toProps.positions !== fromProps.positions) {
+    if (!isEqual(toProps.positions, fromProps.positions)) {
       this.leafletElement.setLatLngs(toProps.positions)
     }
     this.setStyleIfChanged(fromProps, toProps)

--- a/src/Polyline.js
+++ b/src/Polyline.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { Polyline as LeafletPolyline } from 'leaflet'
+import isEqual from 'fast-deep-equal'
 
 import { withLeaflet } from './context'
 import Path from './Path'
@@ -17,7 +18,7 @@ class Polyline extends Path<LeafletElement, Props> {
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props) {
-    if (toProps.positions !== fromProps.positions) {
+    if (!isEqual(toProps.positions, fromProps.positions)) {
       this.leafletElement.setLatLngs(toProps.positions)
     }
     this.setStyleIfChanged(fromProps, toProps)

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { Popup as LeafletPopup } from 'leaflet'
+import isEqual from 'fast-deep-equal'
 
 import { withLeaflet } from './context'
 import DivOverlay from './DivOverlay'
@@ -31,7 +32,7 @@ class Popup extends DivOverlay<LeafletElement, Props> {
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props) {
-    if (toProps.position !== fromProps.position) {
+    if (!isEqual(toProps.position, fromProps.position)) {
       this.leafletElement.setLatLng(toProps.position)
     }
   }

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { Rectangle as LeafletRectangle } from 'leaflet'
+import isEqual from 'fast-deep-equal'
 
 import { withLeaflet } from './context'
 import Path from './Path'
@@ -15,7 +16,7 @@ class Rectangle extends Path<LeafletElement, Props> {
   }
 
   updateLeafletElement(fromProps: Props, toProps: Props) {
-    if (toProps.bounds !== fromProps.bounds) {
+    if (!isEqual(toProps.bounds, fromProps.bounds)) {
       this.leafletElement.setBounds(toProps.bounds)
     }
     this.setStyleIfChanged(fromProps, toProps)

--- a/src/VideoOverlay.js
+++ b/src/VideoOverlay.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { VideoOverlay as LeafletVideoOverlay, latLngBounds } from 'leaflet'
+import isEqual from 'fast-deep-equal'
 
 import { withLeaflet } from './context'
 import MapLayer from './MapLayer'
@@ -36,7 +37,7 @@ class VideoOverlay extends MapLayer<LeafletElement, Props> {
     if (toProps.url !== fromProps.url) {
       this.leafletElement.setUrl(toProps.url)
     }
-    if (toProps.bounds !== fromProps.bounds) {
+    if (!isEqual(toProps.bounds, fromProps.bounds)) {
       this.leafletElement.setBounds(latLngBounds(toProps.bounds))
     }
     if (toProps.opacity !== fromProps.opacity) {


### PR DESCRIPTION
This PR uses the already present `fast-is-equal` package and replaces all object comparisons (`obj1 === obj2` or `obj1 !== obj2`) with `isEqual` calls to actually compare their props and not their internal references.

This is needed to avoid leaflet elements re-rendering when props didn't actually change, which may cause third party code or libraries to receive update events and behave unexpectedly.

My case was [react-leaflet-markercluster](https://www.npmjs.com/package/react-leaflet-markercluster) that received a `"move"` event when I clicked a marker as `Marker.prototype.updateLeafletElement` did behave like the location props did change, although there were no difference between the `prevProps` and current `props`. 

I saw some issues / PRs that talked about the issue but people seemed to find other ways to handle the case, but this seem like a good thing to handle properly to avoid unexpected issues, since it took me several hours to track this down.