### PR TITLE
Add support for doubleClickZoom option's "center" setting

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -209,7 +209,8 @@ export default class Map extends MapEvented<LeafletElement, Props> {
     }
 
     if (doubleClickZoom !== fromProps.doubleClickZoom) {
-      if (doubleClickZoom === true) {
+      if (doubleClickZoom === true || typeof doubleClickZoom === 'string') {
+        this.leafletElement.options.doubleClickZoom = doubleClickZoom
         this.leafletElement.doubleClickZoom.enable()
       } else {
         this.leafletElement.doubleClickZoom.disable()


### PR DESCRIPTION
The `doubleClickZoom` option also supports the `"center"` setting as e.g. `scrollWheelZoom` does. This patch adds the missing support for it.