### PR TITLE
new package for react-leaflet-bing

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,7 +13,7 @@ open pull requests to update this list!
 | [`leaflet-drift-marker`](https://www.npmjs.com/package/leaflet-drift-marker)                                     | **yes**            |
 | [`leaflet-react-track-player`](https://www.npmjs.com/package/leaflet-react-track-player)                         | unknown            |
 | [`react-leaflet-ant-path`](https://www.npmjs.com/package/react-leaflet-ant-path)                                 | unknown            |
-| [`react-leaflet-bing`](https://www.npmjs.com/package/react-leaflet-bing)                                         | **yes**            |
+| [`react-leaflet-bing-v2`](https://www.npmjs.com/package/react-leaflet-bing-v2)                                   | **yes**            |
 | [`react-leaflet-box-zoom`](https://www.npmjs.com/package/react-leaflet-box-zoom)                                 | **yes**            |
 | [`react-leaflet-choropleth`](https://www.npmjs.com/package/react-leaflet-choropleth)                             | unknown            |
 | [`react-leaflet-cluster-layer`](https://www.npmjs.com/package/react-leaflet-cluster-layer)                       | unknown            |


### PR DESCRIPTION
react-leaflet-bing is now obsolete. The new package name is react-leaflet-bing-v2