### PR TITLE
update react-leaflet-google plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -34,7 +34,7 @@ open pull requests to update this list!
 | [`react-leaflet-fullscreen-control`](https://www.npmjs.com/package/react-leaflet-fullscreen-control)             | unknown            |
 | [`react-leaflet-geojson-cluster`](https://www.npmjs.com/package/react-leaflet-geojson-cluster)                   | unknown            |
 | [`react-leaflet-geojson-patterns`](https://www.npmjs.com/package/react-leaflet-geojson-patterns)                 | **yes**            |
-| [`react-leaflet-google`](https://www.npmjs.com/package/react-leaflet-google)                                     | **yes**            |
+| [`react-leaflet-google-v2`](https://www.npmjs.com/package/react-leaflet-google-v2)                               | **yes**            |
 | [`react-leaflet-google-layer`](https://www.npmjs.com/package/react-leaflet-google-layer)                         | **yes**            |
 | [`react-leaflet-heatmap-layer`](https://www.npmjs.com/package/react-leaflet-heatmap-layer)                       | **yes**            |
 | [`react-leaflet-locate-control`](https://www.npmjs.com/package/react-leaflet-locate-control)                     | **no**             |


### PR DESCRIPTION
the react-leaflet-google is obsolete. Now, they can use react-leaflet-google-v2 package.