### PR TITLE
utils/pick should catch falsy values

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "peerDependencies": {
     "leaflet": "^1.6.0",
     "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react-dom": "^16.8.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "peerDependencies": {
     "leaflet": "^1.6.0",
     "react": "^16.8.0",
-    "react-dom": "^16.8.4"
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",

--- a/src/utils/pick.js
+++ b/src/utils/pick.js
@@ -2,7 +2,7 @@
 
 export default function pick(object: Object, keys: Array<string>): Object {
   return keys.reduce((obj, key) => {
-    if (object[key] !== 'undefined') {
+    if (object[key] !== undefined) {
       obj[key] = object[key]
     }
     return obj

--- a/src/utils/pick.js
+++ b/src/utils/pick.js
@@ -2,7 +2,7 @@
 
 export default function pick(object: Object, keys: Array<string>): Object {
   return keys.reduce((obj, key) => {
-    if (object[key]) {
+    if (object[key] !== 'undefined') {
       obj[key] = object[key]
     }
     return obj

--- a/src/utils/pick.js
+++ b/src/utils/pick.js
@@ -2,7 +2,7 @@
 
 export default function pick(object: Object, keys: Array<string>): Object {
   return keys.reduce((obj, key) => {
-    if (object[key] !== undefined) {
+    if (typeof object[key] !== 'undefined') {
       obj[key] = object[key]
     }
     return obj


### PR DESCRIPTION
When updating dynamic `Path` options, only truthy values are picked out of props to be updated. Path options can have valid falsy values, like `fillOpacity: 0` or `bubblingMouseEvents: false`. It is possible to initialize a dynamic property to a falsy value, but after changing it to a truthy one, it cannot be changed back. This PR changes `utils/pick.js` so that it will pick any value that isn't `=== undefined`.