### PR TITLE
Add react-leaflet-geodesic to plugins.md

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -57,3 +57,4 @@ open pull requests to update this list!
 | [`react-leaflet-zoom-display`](https://www.npmjs.com/package/react-leaflet-zoom-display)                         | unknown            |
 | [`react-leaflet-zoom-indicator`](https://www.npmjs.com/package/react-leaflet-zoom-indicator)                     | unknown            |
 | [`react-mapbox-components`](https://www.npmjs.com/package/react-mapbox-components)                               | unknown            |
+| [`react-leaflet-geodesic`](https://www.npmjs.com/package/react-leaflet-geodesic)                                 | **yes**            |


### PR DESCRIPTION
Recent part-wrap of Leaflet.Geodesic to React.
Although it still has only GeodesicLine, I think it would be usefull to people that might need it.