### PR TITLE
Add `prefix` property to AttributionControl docs.

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -404,6 +404,7 @@ Use the `LayerGroup` wrapper component to group children layers together.
 **Dynamic properties**
 
 - `position: controlPosition` (optional)
+- `prefix: boolean` (optional)
 
 ### LayersControl
 


### PR DESCRIPTION
An example of how to disable AttributionControl prefix: `<AttributionControl prefix={false} />`