### PR TITLE
Set babel runtime version to make smaller bundle

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -23,7 +23,7 @@
         "@babel/preset-flow",
         "@babel/preset-react"
       ],
-      "plugins": ["@babel/plugin-transform-runtime"]
+      "plugins": [["@babel/plugin-transform-runtime", { "version": "^7.8.3" }]]
     },
     "rollup": {
       "presets": [
@@ -40,9 +40,7 @@
         "@babel/preset-flow",
         "@babel/preset-react"
       ],
-      "plugins": [
-        "@babel/plugin-transform-runtime"
-      ]
+      "plugins": [["@babel/plugin-transform-runtime", { "version": "^7.8.3" }]]
     },
     "jsnext": {
       "presets": [
@@ -61,7 +59,10 @@
         "@babel/preset-react"
       ],
       "plugins": [
-        ["@babel/plugin-transform-runtime", { "useESModules": true }]
+        [
+          "@babel/plugin-transform-runtime",
+          { "useESModules": true, "version": "^7.8.3" }
+        ]
       ]
     }
   }


### PR DESCRIPTION
This sets used runtime version for @babel/transform-runtime.
https://babeljs.io/docs/en/babel-plugin-transform-runtime#version

It results in a smaller bundle, as transform can depend on newer features be present on runtime.

Before:
```
97810 react-leaflet.js
42915 react-leaflet.min.js
```

After:
```
87280 react-leaflet.js
36061 react-leaflet.min.js
```

By using .babelrc.js, the version could come from package.json like this: 
```javascript
const ENV = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
const pkg = require('./package.json');
const runtimeVersion = pkg.dependencies['@babel/runtime'];
```

But probably the need for version field is removed in Babel 8 anyway.
