### PR TITLE
Add viewBox and preserveAspectRatio props to SVGOverlay element

### DIFF
--- a/example/components/svg-overlay.js
+++ b/example/components/svg-overlay.js
@@ -18,7 +18,7 @@ export default class SVGOverlayExample extends Component<{}> {
           attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        <SVGOverlay bounds={rectangle}>
+        <SVGOverlay bounds={rectangle} viewBox="0 0 80 80">
           <rect x="0" y="0" width="100%" height="100%" fill="blue" />
           <circle r="5" cx="10" cy="10" fill="red" />
           <text x="50%" y="50%" fill="white">

--- a/src/SVGOverlay.js
+++ b/src/SVGOverlay.js
@@ -10,6 +10,14 @@ import MapComponent from './MapComponent'
 type LeafletElement = LeafletSVGOverlay
 type Props = SVGOverlayProps
 
+function setAttribute(el: Element, name: string, value: ?string): void {
+  if (value != null) {
+    el.setAttribute(name, value)
+  } else {
+    el.removeAttribute(name)
+  }
+}
+
 class SVGOverlay extends MapComponent<LeafletElement, Props> {
   leafletElement: LeafletElement
   container: ?Element
@@ -24,19 +32,17 @@ class SVGOverlay extends MapComponent<LeafletElement, Props> {
   }
 
   createLeafletElement(props: Props): LeafletElement {
-    this.container = document.createElementNS(
+    const container = document.createElementNS(
       'http://www.w3.org/2000/svg',
       'svg',
     )
-    this.container.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
-    if (props.viewBox) {
-        this.container.setAttribute('viewBox', props.viewBox)
-    }
-    if (props.preserveAspectRatio) {
-        this.container.setAttribute('preserveAspectRatio', props.preserveAspectRatio)
-    }
+    setAttribute(container, 'xmlns', 'http://www.w3.org/2000/svg')
+    setAttribute(container, 'preserveAspectRatio', props.preserveAspectRatio)
+    setAttribute(container, 'viewBox', props.viewBox)
+
+    this.container = container
     return new LeafletSVGOverlay(
-      this.container,
+      container,
       props.bounds,
       this.getOptions(props),
     )
@@ -49,11 +55,18 @@ class SVGOverlay extends MapComponent<LeafletElement, Props> {
     if (toProps.opacity !== fromProps.opacity) {
       this.leafletElement.setOpacity(toProps.opacity)
     }
-    if (toProps.preserveAspectRatio !== fromProps.preserveAspectRatio) {
-      this.container.setAttribute('preserveAspectRatio', toProps.preserveAspectRatio)
+    if (
+      this.container &&
+      toProps.preserveAspectRatio !== fromProps.preserveAspectRatio
+    ) {
+      setAttribute(
+        this.container,
+        'preserveAspectRatio',
+        toProps.preserveAspectRatio,
+      )
     }
-    if (toProps.viewBox !== fromProps.viewBox) {
-      this.container.setAttribute('viewBox', toProps.viewBox)
+    if (this.container && toProps.viewBox !== fromProps.viewBox) {
+      setAttribute(this.container, 'viewBox', toProps.viewBox)
     }
     if (toProps.zIndex !== fromProps.zIndex) {
       this.leafletElement.setZIndex(toProps.zIndex)

--- a/src/SVGOverlay.js
+++ b/src/SVGOverlay.js
@@ -28,6 +28,13 @@ class SVGOverlay extends MapComponent<LeafletElement, Props> {
       'http://www.w3.org/2000/svg',
       'svg',
     )
+    this.container.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+    if (props.viewBox) {
+        this.container.setAttribute('viewBox', props.viewBox)
+    }
+    if (props.preserveAspectRatio) {
+        this.container.setAttribute('preserveAspectRatio', props.preserveAspectRatio)
+    }
     return new LeafletSVGOverlay(
       this.container,
       props.bounds,
@@ -41,6 +48,12 @@ class SVGOverlay extends MapComponent<LeafletElement, Props> {
     }
     if (toProps.opacity !== fromProps.opacity) {
       this.leafletElement.setOpacity(toProps.opacity)
+    }
+    if (toProps.preserveAspectRatio !== fromProps.preserveAspectRatio) {
+      this.container.setAttribute('preserveAspectRatio', toProps.preserveAspectRatio)
+    }
+    if (toProps.viewBox !== fromProps.viewBox) {
+      this.container.setAttribute('viewBox', toProps.viewBox)
     }
     if (toProps.zIndex !== fromProps.zIndex) {
       this.leafletElement.setZIndex(toProps.zIndex)

--- a/src/types.js
+++ b/src/types.js
@@ -129,4 +129,6 @@ export type SVGOverlayProps = MapComponentProps &
   ImageOverlayOptions & {
     bounds: LatLngBounds,
     children?: Node,
+    preserveAspectRatio?: string,
+    viewBox?: string,
   }


### PR DESCRIPTION
Simply the suggestions in #702 as an actual pull request.
- Add `viewBox` property.
- Add `preserveAspectRatio` property (it works hands in hands with `viewBox`).
- Set the `xmlns` attribute. Not *required* but cleaner and matches leaflet.js documentation.

Fixes #702.