### PR TITLE
Drop support for IE in v3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,12 @@
             "modules": "commonjs",
             "targets": {
               "node": "current",
-              "browsers": "last 2 versions"
+              "browsers": [
+                "last 2 versions",
+                "not dead",
+                "not ie > 0",
+                "not ie_mob > 0"
+              ]
             },
             "useBuiltIns": "usage"
           }
@@ -35,7 +40,12 @@
             "modules": false,
             "targets": {
               "node": "current",
-              "browsers": "last 2 versions"
+              "browsers": [
+                "last 2 versions",
+                "not dead",
+                "not ie > 0",
+                "not ie_mob > 0"
+              ]
             },
             "useBuiltIns": "usage"
           }
@@ -58,7 +68,12 @@
             "modules": false,
             "targets": {
               "node": "current",
-              "browsers": "last 2 versions"
+              "browsers": [
+                "last 2 versions",
+                "not dead",
+                "not ie > 0",
+                "not ie_mob > 0"
+              ]
             },
             "useBuiltIns": "usage"
           }

--- a/.babelrc
+++ b/.babelrc
@@ -13,10 +13,13 @@
             "targets": {
               "node": "current",
               "browsers": [
-                "last 2 versions",
-                "not dead",
-                "not ie > 0",
-                "not ie_mob > 0"
+                "last 2 Chrome versions",
+                "last 2 Edge versions",
+                "last 2 Firefox versions",
+                "last 2 iOS versions",
+                "last 2 Opera versions",
+                "last 2 Safari versions",
+                "last 2 Samsung versions"
               ]
             },
             "useBuiltIns": "usage"
@@ -41,10 +44,13 @@
             "targets": {
               "node": "current",
               "browsers": [
-                "last 2 versions",
-                "not dead",
-                "not ie > 0",
-                "not ie_mob > 0"
+                "last 2 Chrome versions",
+                "last 2 Edge versions",
+                "last 2 Firefox versions",
+                "last 2 iOS versions",
+                "last 2 Opera versions",
+                "last 2 Safari versions",
+                "last 2 Samsung versions"
               ]
             },
             "useBuiltIns": "usage"
@@ -69,10 +75,13 @@
             "targets": {
               "node": "current",
               "browsers": [
-                "last 2 versions",
-                "not dead",
-                "not ie > 0",
-                "not ie_mob > 0"
+                "last 2 Chrome versions",
+                "last 2 Edge versions",
+                "last 2 Firefox versions",
+                "last 2 iOS versions",
+                "last 2 Opera versions",
+                "last 2 Safari versions",
+                "last 2 Samsung versions"
               ]
             },
             "useBuiltIns": "usage"


### PR DESCRIPTION
### What?
This drops support for IE.

This results in a following current (but moving) browser support:
```json
{
  "android": "81",
  "chrome": "81",
  "edge": "81",
  "firefox": "77",
  "ios": "13.3",
  "node": "12.18.2",
  "opera": "68",
  "safari": "13",
  "samsung": "11.1"
}
```

### Why?
The issue #698 noted that support for IE will be dropped in v3. However the babel config is using "last 2 versions" which includes both IE 10 and 11.

I think it would be better to explicitly declare supported browsers:
```json
"browsers": [
  "Chrome >= 73",
  "ChromeAndroid >= 73",
  "Firefox >= 68",
  "Edge >= 18",
  "Safari >= 12",
  "Samsung >= 10",
  "iOS >= 12"
]
```

Without explicit browser support almost all users of react-leaflet need to transpile down to their set of browsers.