### PR TITLE
Drop @babel/runtime and polyfilling

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,6 @@
         [
           "@babel/preset-env",
           {
-            "corejs": 3,
             "loose": true,
             "modules": "commonjs",
             "targets": {
@@ -20,15 +19,8 @@
                 "last 2 Safari versions",
                 "last 2 Samsung versions"
               ]
-            },
-            "useBuiltIns": "usage"
+            }
           }
-        ]
-      ],
-      "plugins": [
-        [
-          "@babel/plugin-transform-runtime",
-          { "corejs": 3, "version": "^7.10.4" }
         ]
       ]
     },
@@ -37,7 +29,6 @@
         [
           "@babel/preset-env",
           {
-            "corejs": 3,
             "loose": true,
             "modules": false,
             "targets": {
@@ -51,15 +42,8 @@
                 "last 2 Safari versions",
                 "last 2 Samsung versions"
               ]
-            },
-            "useBuiltIns": "usage"
+            }
           }
-        ]
-      ],
-      "plugins": [
-        [
-          "@babel/plugin-transform-runtime",
-          { "corejs": 3, "version": "^7.10.4" }
         ]
       ]
     },
@@ -68,7 +52,6 @@
         [
           "@babel/preset-env",
           {
-            "corejs": 3,
             "loose": true,
             "modules": false,
             "targets": {
@@ -82,15 +65,8 @@
                 "last 2 Safari versions",
                 "last 2 Samsung versions"
               ]
-            },
-            "useBuiltIns": "usage"
+            }
           }
-        ]
-      ],
-      "plugins": [
-        [
-          "@babel/plugin-transform-runtime",
-          { "corejs": 3, "useESModules": true, "version": "^7.10.4" }
         ]
       ]
     }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/plugin-proposal-export-default-from": "^7.10.4",
     "@babel/plugin-transform-proto-to-assign": "^7.10.5",
-    "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/plugin-transform-strict-mode": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.10.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,10 +39,6 @@
     "esm/*",
     "types/*"
   ],
-  "dependencies": {
-    "@babel/runtime-corejs3": "^7.10.5",
-    "core-js": "^3.6.5"
-  },
   "peerDependencies": {
     "leaflet": "^1.6.0",
     "react": "^16.9.0",

--- a/packages/react-leaflet/package.json
+++ b/packages/react-leaflet/package.json
@@ -43,9 +43,7 @@
     "umd/*"
   ],
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.10.5",
-    "@react-leaflet/core": "^1.0.0-beta.3",
-    "core-js": "^3.6.5"
+    "@react-leaflet/core": "^1.0.0-beta.3"
   },
   "peerDependencies": {
     "leaflet": "^1.6.0",

--- a/packages/react-leaflet/rollup.config.js
+++ b/packages/react-leaflet/rollup.config.js
@@ -32,7 +32,6 @@ const config = {
     babel({
       exclude: '**/node_modules/**',
       extensions,
-      runtimeHelpers: true,
     }),
     replace({
       'process.env.NODE_ENV': JSON.stringify(env),

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,7 +873,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-runtime@^7.10.5", "@babel/plugin-transform-runtime@^7.9.0":
+"@babel/plugin-transform-runtime@^7.9.0":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.5.tgz#3b39b7b24830e0c2d8ff7a4489fe5cf99fbace86"
   integrity sha512-tV4V/FjElJ9lQtyjr5xD2IFFbgY46r7EeVu5a8CpEKT5laheHKSlFeHjpkPppW3PqzGLAuv5k2qZX5LgVZIX5w==
@@ -1053,7 +1053,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-transform-typescript" "^7.10.4"
 
-"@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.10.4", "@babel/runtime-corejs3@^7.10.5":
+"@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.10.4":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.5.tgz#a57fe6c13045ca33768a2aa527ead795146febe1"
   integrity sha512-RMafpmrNB5E/bwdSphLr8a8++9TosnyJp98RZzI6VOx2R2CCMpsXXXRvmI700O9oEKpXdZat6oEK68/F0zjd4A==
@@ -4028,11 +4028,6 @@ core-js@^2.4.1, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
-
-core-js@^3.6.5:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
### What?
This PR removes runtime transform and polyfilling from babel config.

### Why?

1. The runtime and polyfills are not needed as only last 2 versions of browsers are supported
2. It saves bundle size. The UMD bundle is now only 11kB, down from 44kB.

### What else?

The docusaurus build seems to be failing. It also fails for me on branch 'next', so it should not be caused by this PR.