### PR TITLE
Fix: Fixed incorrect react example

### DIFF
--- a/packages/website/docs/api-map.md
+++ b/packages/website/docs/api-map.md
@@ -107,7 +107,7 @@ function MyMapComponent() {
           console.log('map center:', map.getCenter())
           return null
         }}
-      <MapConsumer>
+      </MapConsumer>
     </MapContainer>
   )
 }


### PR DESCRIPTION
I'm founded an incorrect example in documentation for `next` (v3) version of library when I research examples.

Before:
```
<MapConsumer>
    ...
<MapConsumer>  {/* Example without slash */}
```


After:
```
<MapConsumer>
    ...
</MapConsumer> {/* Example with slash */}
```