### PR TITLE
Document pathOptions for GeoJSON

### DIFF
--- a/packages/website/docs/api-components.md
+++ b/packages/website/docs/api-components.md
@@ -389,6 +389,7 @@ The `attributes` must be valid [`SVGSVGElement` properties](https://developer.mo
 | `data`          | `GeoJsonObject`              | **Yes**  | No      |
 | `eventHandlers` | `LeafletEventHandlerFnMap`   | No       | **Yes** | [Evented](#evented-behavior)                 |
 | `pane`          | `string`                     | No       | No      | [Pane](#pane-behavior)                       |
+| `pathOptions`   | `PathOptions`                | No       | **Yes** | [Path](#path-behavior)                       |
 | `ref`           | `RefObject<Leaflet.GeoJSON>` | No       | **Yes** | [Referenceable](#referenceable-behavior)     |
 
 ## Controls


### PR DESCRIPTION
This adds documentation for the GeoJSON showing that it has `pathOptions` prop, same as Rectangle et al.

~It's marked Mutable like for the other Components and changing it is actually delegated to the leaflet object, however it does not work as it needs [`resetStyle()`](https://leafletjs.com/reference-1.7.1.html#geojson-resetstyle) to be called.~

~Setting a different `color` or `weight` via `pathOptions` on a `<Rectangle.../>` did neither work for me, so I wonder if it's a bug or if is intended but the documentation is misleading.~

Edit: Nevermind the update issues. It's updating. I was setting only the sub-property not the whole pathOptions. My problem can be reproduced with the third case within in https://codesandbox.io/s/xenodochial-proskuriakova-pytgj?file=/src/Map.js:8695-8722 and is most likely intentional functionality.