### PR TITLE
Add whenDestroyed handler to MapContainer

### DIFF
--- a/packages/react-leaflet/__tests__/MapContainer.tsx
+++ b/packages/react-leaflet/__tests__/MapContainer.tsx
@@ -65,6 +65,23 @@ describe('MapContainer', () => {
 
       render(<TestContainer />)
     })
+
+    test('in the whenDestroyed() callback', (done) => {
+      function TestContainer() {
+        return (
+          <MapContainer
+            center={[0, 0]}
+            zoom={10}
+            whenDestroyed={() => {
+              done()
+            }}
+          />
+        )
+      }
+
+      const { unmount } = render(<TestContainer />)
+      unmount()
+    })
   })
 
   test('sets center and zoom props', (done) => {

--- a/packages/react-leaflet/src/MapContainer.tsx
+++ b/packages/react-leaflet/src/MapContainer.tsx
@@ -28,6 +28,7 @@ export interface MapContainerProps extends MapOptions, EventedProps {
   placeholder?: ReactNode
   style?: CSSProperties
   whenCreated?: (map: LeafletMap) => void
+  whenDestroyed?: () => void
   whenReady?: () => void
 }
 
@@ -62,6 +63,7 @@ export function MapContainer({
   placeholder,
   style,
   whenCreated,
+  whenDestroyed,
   ...options
 }: MapContainerProps) {
   const mapRef = useRef<HTMLDivElement>(null)
@@ -73,6 +75,7 @@ export function MapContainer({
       createdRef.current = true
       whenCreated(map)
     }
+    return () => whenDestroyed?.call(undefined)
   }, [map, whenCreated])
 
   const context = useMemo(

--- a/packages/website/docs/api-map.md
+++ b/packages/website/docs/api-map.md
@@ -20,6 +20,7 @@ The following additional props are supported:
 | `placeholder`   | `ReactNode`                  |
 | `style`         | `CSSProperties`              |
 | `whenCreated`   | `(map: Leaflet.Map) => void` |
+| `whenDestroyed` | `() => void`                 |
 | `whenReady`     | `() => void`                 |
 
 Except for its `children`, `MapContainer` props are **immutable**: changing them after they have been set a first time will have no effect on the Map instance or its container.  

--- a/packages/website/docs/example-external-state.md
+++ b/packages/website/docs/example-external-state.md
@@ -41,7 +41,8 @@ function ExternalStateExample() {
         center={center}
         zoom={zoom}
         scrollWheelZoom={false}
-        whenCreated={setMap}>
+        whenCreated={setMap}
+        whenDestroyed={() => setMap(null)}>
         <TileLayer
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"


### PR DESCRIPTION
This adds the whenDestroyed handler to MapContainer. It complements whenCreated and allows cleaning up to not have memory leaks when dealing with external state.