### PR TITLE
Fix a library name typo in install docs

### DIFF
--- a/packages/website/docs/start-installation.mdx
+++ b/packages/website/docs/start-installation.mdx
@@ -74,7 +74,7 @@ yarn add react-leaflet
 Finally, you import the necessary components, for example:
 
 ```js
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leafet'
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
 ```
 
 ## Using TypeScript


### PR DESCRIPTION
I was going through the docs and for a few minutes I got stuck, not understanding why my library import wasn't working. :) 