### PR TITLE
Improve the out-of-the-box setup instructions

### DIFF
--- a/packages/website/docs/start-setup.md
+++ b/packages/website/docs/start-setup.md
@@ -3,15 +3,28 @@ title: Setup
 ---
 
 1. Follow all the steps from the [installation page](start-installation.mdx)
-1. Add the following code to your app and check it displays correctly:
+1. Ensure that the leaflet css is included in your project.  E.g. for a typical babel app:
 
 ```tsx live
-<MapContainer center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false}>
+import 'leaflet/dist/leaflet.css'
+```
+
+3. Now add the following code to your app and check it displays correctly:
+
+```tsx live
+import markerIconPng from "leaflet/dist/images/marker-icon.png"
+import {Icon} from 'leaflet'
+
+// The default bundler configuration will not work with the way leaflet loads
+// its images, so doing this avoids seeing broken image icons.
+const markerIcon = new new Icon({iconUrl: markerIconPng})
+
+<MapContainer center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false} style={{height: 500}}>
   <TileLayer
     attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
   />
-  <Marker position={[51.505, -0.09]}>
+  <Marker position={[51.505, -0.09]} icon={markerIcon})}>
     <Popup>
       A pretty CSS3 popup. <br /> Easily customizable.
     </Popup>

--- a/packages/website/docs/start-setup.md
+++ b/packages/website/docs/start-setup.md
@@ -17,7 +17,9 @@ import {Icon} from 'leaflet'
 
 // The default bundler configuration will not work with the way leaflet loads
 // its images, so doing this avoids seeing broken image icons.
-const markerIcon = new new Icon({iconUrl: markerIconPng})
+const markerIcon = new Icon({
+    iconUrl: markerIconPng, iconSize: [25, 41], iconAnchor: [12, 41]
+})
 
 <MapContainer center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false} style={{height: 500}}>
   <TileLayer


### PR DESCRIPTION
Working with create-react-app, the instructions didn't work out of the box for three reasons:
1. The instructions didn't explain how to include the leaflet CSS
2. The container had no height
3. The create react app bundler doesn't work with leaflet icons.  See https://stackoverflow.com/questions/60174040/marker-icon-isnt-showing-in-leaflet

Since this is the 'getting started', I think it's better to get it working nicely, even if it's not exactly best practice (e.g. people should set their container height in CSS elsewhere).