### PR TITLE
Fix TS Build Target - Compile Nullish Coalescing for broader Webpack/Babel/Node support

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2019"
+    "target": "es2018"
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
Fixes: https://github.com/PaulLeCam/react-leaflet/issues/883

This PR is meant to fix some issues that exist with the current version of the built code. Using `ES2018` as the build target will ensure that no `??` syntax will make it into the build output. Unfortunately this syntax does not have broad support for packages like `webpack@4` and other bundlers. I've run into these issues running my tests in node using `js-dom` as well. 

The impact should be low here (bundle size may increase a slight bit) but will make the library much easier to use for people using `next.js` and `create-react-app` as well as people with highly custom webpack setups and those who have not made it to webpack 5 yet.