### PR TITLE
fix: #891, #883, #882, #881

### DIFF
--- a/packages/react-leaflet/package.json
+++ b/packages/react-leaflet/package.json
@@ -42,13 +42,11 @@
     "types/*",
     "umd/*"
   ],
-  "dependencies": {
-    "@react-leaflet/core": "^1.1.0"
-  },
   "peerDependencies": {
     "leaflet": "^1.7.1",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react-dom": "^17.0.1",
+    "@react-leaflet/core": "^1.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^5.3.0",

--- a/packages/react-leaflet/rollup.config.js
+++ b/packages/react-leaflet/rollup.config.js
@@ -22,7 +22,7 @@ const config = {
     },
     name: 'ReactLeaflet',
   },
-  external: ['leaflet', 'react', 'react-dom'],
+  external: ['leaflet', 'react', 'react-dom', '@react-leaflet/core'],
   plugins: [
     nodeResolve({
       browser: true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2019"
+    "target": "es2018"
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
Fixes Issues: 

- [#891](https://github.com/PaulLeCam/react-leaflet/issues/891)
- [#883](https://github.com/PaulLeCam/react-leaflet/issues/#883) 
- [#882](https://github.com/PaulLeCam/react-leaflet/issues/#882)
- [#883](https://github.com/PaulLeCam/react-leaflet/issues/##881) 

Also fixes an issue when using/developing components from external packages by requiring '@react-leaflet/core' as a peer dependecy:

`No context provided: useLeafletContext() can only be used in a descendant of <MapContainer>`

Since @react-leaflet/core, and consequently `useLeafletContext`, are bundled with react-leaflet, components created with core do not have access to the same context as the MapContainer. This is only achievable by excluding @react-leafler/core from the bundle of react-leaflet.