### PR TITLE
Fix layer unmount

### DIFF
--- a/packages/core/src/layer.ts
+++ b/packages/core/src/layer.ts
@@ -22,7 +22,7 @@ export function useLayerLifecycle(
       container.addLayer(element.instance)
 
       return function removeLayer() {
-        context.layersControl?.removeLayer(element.instance)
+        context.layerContainer?.removeLayer(element.instance)
         context.map.removeLayer(element.instance)
       }
     },


### PR DESCRIPTION
There was a typo in the 3.2.0 update. Markers were not removed from the layerContainer.

Fix https://github.com/PaulLeCam/react-leaflet/issues/898
Fix https://github.com/PaulLeCam/react-leaflet/issues/832