### PR TITLE
Improve setup example code snippet

### DIFF
--- a/packages/website/docs/start-setup.md
+++ b/packages/website/docs/start-setup.md
@@ -6,7 +6,7 @@ title: Setup
 1. Add the following code to your app and check it displays correctly:
 
 ```tsx live
-<MapContainer center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false} id="my-leaflet-map-container">
+<MapContainer center={[51.505, -0.09]} zoom={13} id="my-leaflet-map-container">
   <TileLayer
     attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/packages/website/docs/start-setup.md
+++ b/packages/website/docs/start-setup.md
@@ -6,7 +6,7 @@ title: Setup
 1. Add the following code to your app and check it displays correctly:
 
 ```tsx live
-<MapContainer center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false}>
+<MapContainer center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false} id="my-leaflet-map-container">
   <TileLayer
     attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"


### PR DESCRIPTION
Two very small changes to help the first-time user fall into the fabled pit of success. 

- How I should introduce my map container CSS to `react-leaflet`? I was left scratching my head this afternoon about this. In retrospect it is very obvious, but it was not initially to me. Since (I infer) you must include either an `id` or `className` attribute to the main component for the whole thing to work - and to avoid staring at a blank screen - we should include an example of that in the quickstart.
- The next mystery was why the mousewheel didn't work. What is the benefit of adding a non-default setting to a quickstart example? Again, perhaps it seems obvious the setting is there - but not to a first-time user juggling Leaflet, React, react-leaflet and whatever infernal web build system they are trying out today.  😊