### PR TITLE
Set build target to es2015

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2019"
+    "target": "es2015"
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
Changing the build target to es2015 will enable easier use of the library in all sorts of projects without having to make changes in babel configs etc.

Should fix https://github.com/PaulLeCam/react-leaflet/issues/877 without making any changes in the code so you can still use nullish coalescing where you want to.