### PR TITLE
Fix Popup onClose and onOpen documented as mutable

### DIFF
--- a/packages/website/docs/api-components.md
+++ b/packages/website/docs/api-components.md
@@ -158,8 +158,8 @@ Applies to [control components](#controls), making their [`position: ControlPosi
 | `attribution`   | `string`                   | No       | **Yes** | [Attribution](#attribution-behavior)         |
 | `children`      | `ReactNode`                | No       | **Yes** | [ParentComponent](#parentcomponent-behavior) |
 | `eventHandlers` | `LeafletEventHandlerFnMap` | No       | **Yes** | [Evented](#evented-behavior)                 |
-| `onClose`       | `() => void`               | No       | **Yes** |
-| `onOpen`        | `() => void`               | No       | **Yes** |
+| `onClose`       | `() => void`               | No       | No      |
+| `onOpen`        | `() => void`               | No       | No      |
 | `pane`          | `string`                   | No       | No      | [Pane](#pane-behavior)                       |
 | `position`      | `LatLngExpression`         | No       | **Yes** |
 | `ref`           | `RefObject<Leaflet.Popup>` | No       | **Yes** | [Referenceable](#referenceable-behavior)     |


### PR DESCRIPTION
Based on https://github.com/PaulLeCam/react-leaflet/issues/895 and a some tests I made, those props are still not mutable and setting an anonymous function as the value breaks the render of the popup content.