### PR TITLE
fix: HTTP urls updated to https; OSM attribution link updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 React components for Leaflet maps.
 
-## [Documentation](http://react-leaflet.js.org)
+## [Documentation](https://react-leaflet.js.org)
 
 - [Getting started](https://react-leaflet.js.org/docs/start-introduction)
 - [API reference](https://react-leaflet.js.org/docs/api-map)

--- a/packages/website/docs/api-components.md
+++ b/packages/website/docs/api-components.md
@@ -130,7 +130,7 @@ Applies to [control components](#controls), making their [`position: ControlPosi
 
 ### Marker
 
-[Leaflet reference](http://leafletjs.com/reference.html#marker)
+[Leaflet reference](https://leafletjs.com/reference.html#marker)
 
 **Props**
 
@@ -149,7 +149,7 @@ Applies to [control components](#controls), making their [`position: ControlPosi
 
 ### Popup
 
-[Leaflet reference](http://leafletjs.com/reference.html#popup)
+[Leaflet reference](https://leafletjs.com/reference.html#popup)
 
 **Props**
 
@@ -166,7 +166,7 @@ Applies to [control components](#controls), making their [`position: ControlPosi
 
 ### Tooltip
 
-[Leaflet reference](http://leafletjs.com/reference.html#tooltip)
+[Leaflet reference](https://leafletjs.com/reference.html#tooltip)
 
 **Props**
 

--- a/packages/website/docs/core-architecture.md
+++ b/packages/website/docs/core-architecture.md
@@ -44,7 +44,7 @@ const center = [51.505, -0.09]
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Square center={center} size={1000} />
@@ -126,7 +126,7 @@ const center = [51.505, -0.09]
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Square center={center} size={1000} />
@@ -215,7 +215,7 @@ const center = [51.505, -0.09]
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Square center={center} size={1000} />
@@ -292,7 +292,7 @@ const center = [51.505, -0.09]
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Square center={center} size={1000} />
@@ -333,7 +333,7 @@ const center = [51.505, -0.09]
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Square center={center} size={1000} />
@@ -371,7 +371,7 @@ const center = [51.505, -0.09]
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Square center={center} size={1000} />
@@ -410,7 +410,7 @@ const center = [51.505, -0.09]
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Square center={center} size={1000}>
@@ -475,7 +475,7 @@ const center = [51.505, -0.09]
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Square center={center} size={1000}>

--- a/packages/website/docs/example-animated-panning.md
+++ b/packages/website/docs/example-animated-panning.md
@@ -35,7 +35,7 @@ function AnimateExample() {
       </p>
       <MapContainer center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false}>
         <TileLayer
-          attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <SetViewOnClick animateRef={animateRef} />

--- a/packages/website/docs/example-draggable-marker.md
+++ b/packages/website/docs/example-draggable-marker.md
@@ -47,7 +47,7 @@ function DraggableMarker() {
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <DraggableMarker />

--- a/packages/website/docs/example-events.md
+++ b/packages/website/docs/example-events.md
@@ -32,7 +32,7 @@ render(
     zoom={13}
     scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <LocationMarker />

--- a/packages/website/docs/example-external-state.md
+++ b/packages/website/docs/example-external-state.md
@@ -43,7 +43,7 @@ function ExternalStateExample() {
         scrollWheelZoom={false}
         whenCreated={setMap}>
         <TileLayer
-          attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
       </MapContainer>

--- a/packages/website/docs/example-layers-control.md
+++ b/packages/website/docs/example-layers-control.md
@@ -14,13 +14,13 @@ render(
     <LayersControl position="topright">
       <LayersControl.BaseLayer checked name="OpenStreetMap.Mapnik">
         <TileLayer
-          attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
       </LayersControl.BaseLayer>
       <LayersControl.BaseLayer name="OpenStreetMap.BlackAndWhite">
         <TileLayer
-          attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png"
         />
       </LayersControl.BaseLayer>

--- a/packages/website/docs/example-map-placeholder.md
+++ b/packages/website/docs/example-map-placeholder.md
@@ -20,7 +20,7 @@ function MapWithPlaceholder() {
       scrollWheelZoom={false}
       placeholder={<MapPlaceholder />}>
       <TileLayer
-        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
     </MapContainer>

--- a/packages/website/docs/example-other-layers.md
+++ b/packages/website/docs/example-other-layers.md
@@ -17,7 +17,7 @@ const purpleOptions = { color: 'purple' }
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <LayerGroup>

--- a/packages/website/docs/example-panes.md
+++ b/packages/website/docs/example-panes.md
@@ -34,7 +34,7 @@ function BlinkingPane() {
 render(
   <MapContainer bounds={outer} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <BlinkingPane />

--- a/packages/website/docs/example-popup-marker.md
+++ b/packages/website/docs/example-popup-marker.md
@@ -8,7 +8,7 @@ const position = [51.505, -0.09]
 render(
   <MapContainer center={position} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Marker position={position}>

--- a/packages/website/docs/example-react-control.md
+++ b/packages/website/docs/example-react-control.md
@@ -78,7 +78,7 @@ function ReactControlExample() {
   return (
     <MapContainer center={[51.505, -0.09]} zoom={6} scrollWheelZoom={false}>
       <TileLayer
-        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
       <MinimapControl position="topright" />

--- a/packages/website/docs/example-svg-overlay.md
+++ b/packages/website/docs/example-svg-overlay.md
@@ -12,7 +12,7 @@ const bounds = [
 render(
   <MapContainer center={position} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <SVGOverlay attributes={{ stroke: 'red' }} bounds={bounds}>

--- a/packages/website/docs/example-tooltips.md
+++ b/packages/website/docs/example-tooltips.md
@@ -53,7 +53,7 @@ function TooltipCircle() {
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <TooltipCircle />

--- a/packages/website/docs/example-vector-layers.md
+++ b/packages/website/docs/example-vector-layers.md
@@ -57,7 +57,7 @@ const redOptions = { color: 'red' }
 render(
   <MapContainer center={center} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Circle center={center} pathOptions={fillBlueOptions} radius={200} />

--- a/packages/website/docs/example-view-bounds.md
+++ b/packages/website/docs/example-view-bounds.md
@@ -61,7 +61,7 @@ function SetBoundsRectangles() {
 render(
   <MapContainer bounds={outerBounds} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <SetBoundsRectangles />

--- a/packages/website/docs/start-setup.md
+++ b/packages/website/docs/start-setup.md
@@ -8,7 +8,7 @@ title: Setup
 ```tsx live
 <MapContainer center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false}>
   <TileLayer
-    attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
   />
   <Marker position={[51.505, -0.09]}>

--- a/packages/website/src/pages/index.js
+++ b/packages/website/src/pages/index.js
@@ -50,7 +50,7 @@ export default function Home() {
 render(
   <MapContainer center={position} zoom={13} scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
     />
     <Marker position={position}>


### PR DESCRIPTION
I updated a lot of attribution links which still used insecure http. Additionally the attribution links were updated to the current OSM recommendation as shown on this page: https://www.openstreetmap.org/copyright

Updated some other URLs from http to https.