### PR TITLE
Fix a bug where map is removed too soon

### DIFF
--- a/packages/react-leaflet/src/MapContainer.tsx
+++ b/packages/react-leaflet/src/MapContainer.tsx
@@ -71,11 +71,13 @@ export function MapContainer<
       createdRef.current = true
       whenCreated(map)
     }
-
+  }, [map, whenCreated])
+    
+  useEffect(() => {
     return () => {
       map?.remove()
     }
-  }, [map, whenCreated])
+  }, [])
 
   const [props] = useState({ className, id, style })
   const context = useMemo(


### PR DESCRIPTION
Fix the 3.2.4 bug referred in #943 

‘useEffect(…, [xxx])’ could be called multiple times, so ‘map?.remove()’ may be called too soon.

Fixed it by cleaning up with ‘useEffect(…, [])’ which is called only once, at component destruction.