### PR TITLE
Fix duplicate leaflet instantiation in React 18 strict mode

### DIFF
--- a/packages/react-leaflet/src/MapContainer.tsx
+++ b/packages/react-leaflet/src/MapContainer.tsx
@@ -32,9 +32,10 @@ export function useMapElement(
   props: MapContainerProps,
 ): LeafletMap | null {
   const [map, setMap] = useState<LeafletMap | null>(null)
+  const isRenderedRef = useRef<boolean>(false)  
 
   useEffect(() => {
-    if (mapRef.current !== null && map === null) {
+    if (mapRef.current !== null && !isRenderedRef.current) {
       const instance = new LeafletMap(mapRef.current, props)
       if (props.center != null && props.zoom != null) {
         instance.setView(props.center, props.zoom)
@@ -45,8 +46,9 @@ export function useMapElement(
         instance.whenReady(props.whenReady)
       }
       setMap(instance)
+      isRenderedRef.current = true
     }
-  }, [mapRef, map, props])
+  }, [mapRef, props])
 
   return map
 }


### PR DESCRIPTION
React 18 in strict mode simulates an extra unmount + mount cycle in every component's first mount, which results in the rendering effect to run twice with the same conditions, causing a double call to `new LeafletMap()` which leads to an exception in the leaflet library. There are multiple possibilities described in the official react communication (https://github.com/reactwg/react-18/discussions/18) to prevent it, and I tried tearing down the instance (`return () => instance.remove()`), but it led to other problems, and the code already contains teardown logic. So I went with a state-ref useRef way, where the ref keeps its value over unmounts (as opposed to useState), also described here: https://github.com/reactwg/react-18/discussions/18#discussioncomment-801681, so we can effectively prevent the double instantiation.

We still need the `const [map, setMap] = useState...` part, in order for the useEffect hook to be able trigger a rerender after all the refs are having a value.