### PR TITLE
Added steps for adding the Leaflet CSS file

### DIFF
--- a/packages/website/docs/start-installation.mdx
+++ b/packages/website/docs/start-installation.mdx
@@ -97,6 +97,22 @@ yarn add react-leaflet
 </TabItem>
 </Tabs>
 
+### Adding Leaflet CSS
+Add the following CSS file to your component or to the entry JavaScript file.
+
+```js
+import 'leaflet/dist/leaflet.css';
+```
+
+Be sure to set the width and height inside the leaflet-container CSS class inside your component styling
+
+```css
+.leaflet-container {
+  height: 200px;
+  width: 100%;
+}
+```
+
 Modules can then be imported using bare specifiers when supported by a bundler such as [webpack](https://webpack.js.org/).
 
 ```js


### PR DESCRIPTION
Added steps for adding the Leaflet CSS file and overriding the height and width properties.

Followed the given instructions from the installation page, and ran into an issue with the map not rendering properly. Found a [Stack Overflow](https://stackoverflow.com/questions/40365440/react-leaflet-map-not-correctly-displayed) post with the solution. Could not find anything in the introduction, installation page or startup page.

![image](https://user-images.githubusercontent.com/13302928/165365226-8379231b-4e6e-44ac-903d-f95c2677c964.png)
