### PR TITLE
Fixing useRef() usage in createElementHook to prevent unnecessary Leaflet object creation

### DIFF
--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -33,7 +33,9 @@ export function createElementHook<E, P, C = any>(
       props: P,
       context: LeafletContextInterface,
     ): ReturnType<ElementHook<E, P>> {
-      return useRef<LeafletElement<E, C>>(createElement(props, context))
+      const elementRef = useRef<LeafletElement<E, C>>() as MutableRefObject<LeafletElement<E>>;
+      if (!elementRef.current) elementRef.current = createElement(props, context);
+      return elementRef;
     }
   }
 
@@ -41,9 +43,8 @@ export function createElementHook<E, P, C = any>(
     props: P,
     context: LeafletContextInterface,
   ): ReturnType<ElementHook<E, P>> {
-    const elementRef = useRef<LeafletElement<E, C>>(
-      createElement(props, context),
-    )
+    const elementRef = useRef<LeafletElement<E, C>>() as MutableRefObject<LeafletElement<E>>;
+    if (!elementRef.current) elementRef.current = createElement(props, context);
     const propsRef = useRef<P>(props)
     const { instance } = elementRef.current
 

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -33,9 +33,12 @@ export function createElementHook<E, P, C = any>(
       props: P,
       context: LeafletContextInterface,
     ): ReturnType<ElementHook<E, P>> {
-      const elementRef = useRef<LeafletElement<E, C>>() as MutableRefObject<LeafletElement<E>>;
-      if (!elementRef.current) elementRef.current = createElement(props, context);
-      return elementRef;
+      const elementRef = useRef<LeafletElement<E, C>>() as MutableRefObject<
+        LeafletElement<E>
+      >
+      if (!elementRef.current)
+        elementRef.current = createElement(props, context)
+      return elementRef
     }
   }
 
@@ -43,8 +46,10 @@ export function createElementHook<E, P, C = any>(
     props: P,
     context: LeafletContextInterface,
   ): ReturnType<ElementHook<E, P>> {
-    const elementRef = useRef<LeafletElement<E, C>>() as MutableRefObject<LeafletElement<E>>;
-    if (!elementRef.current) elementRef.current = createElement(props, context);
+    const elementRef = useRef<LeafletElement<E, C>>() as MutableRefObject<
+      LeafletElement<E>
+    >
+    if (!elementRef.current) elementRef.current = createElement(props, context)
     const propsRef = useRef<P>(props)
     const { instance } = elementRef.current
 


### PR DESCRIPTION
- WAS: createElement() factory called at every render, therefore nullifying any benefits of using MutableRefObject
- NOW: createElement() factory called only if useRef() does not hold an already cached element object