### PR TITLE
Remove nullish coalescing operator

### DIFF
--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -20,7 +20,7 @@ export function usePathOptions(
   useEffect(
     function updatePathOptions() {
       if (props.pathOptions !== optionsRef.current) {
-        const options = props.pathOptions ?? {}
+        const options = props.pathOptions ? props.pathOptions : {}
         element.instance.setStyle(options)
         optionsRef.current = options
       }


### PR DESCRIPTION
Do not use nullish coalescing operator in order to support all apps that would otherwise have to transpile this library in node_modules manually.

Alternatively this library could be transpiled to es2019 for more backwards compatibility (changing the .swcrc targe to es2019 here https://github.com/PaulLeCam/react-leaflet/blob/master/.swcrc)

This would go a long way, as in order to be able to support nullish coalescing operator, apps need to run webpack > 4. It's not possible currently with CRA 5 and React 18.