### PR TITLE
Transpile to es2019 to increase backwards compatibility

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -4,6 +4,6 @@
       "syntax": "typescript",
       "tsx": true
     },
-    "target": "es2020"
+    "target": "es2019"
   }
 }


### PR DESCRIPTION
Transpile to es2019 for more backwards compatibility. With es2020, the library preserves nullish coalescing operators in the output. Currently, it's necessary to run CRA 5 to support that, which is not compatible with React 18. For the time being it would be best if this library could work without CRA 5, out of the box.