### PR TITLE
Allow ImageOverlay bounds to be changed on the fly again

### DIFF
--- a/packages/react-leaflet/src/ImageOverlay.tsx
+++ b/packages/react-leaflet/src/ImageOverlay.tsx
@@ -28,5 +28,8 @@ export const ImageOverlay = createLayerComponent<
     if (props.url !== prevProps.url) {
       overlay.setUrl(props.url)
     }
+    if (props.bounds !== prevProps.bounds) {
+      overlay.setBounds(props.bounds)
+    }
   },
 )


### PR DESCRIPTION
related pr in the past: https://github.com/PaulLeCam/react-leaflet/pull/328

It was supported in the past, but at some point it was missing.