### PR TITLE
Fixes issue with Map Container is already initialized

### DIFF
--- a/packages/react-leaflet/src/MapContainer.tsx
+++ b/packages/react-leaflet/src/MapContainer.tsx
@@ -67,7 +67,7 @@ function MapContainerComponent<
       setContext(createLeafletContext(map))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [context])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
Was running into this error quite frequently when using this library on a `Next` project where our maps were being loaded using `next/dynamic` to prevent SSR. 

Previous suggestions about adding keys to the `MapContainer` component were not working.

Noticed that the code for checking if we have an existin context is not actually updated if/when the context changes, and instead explicitly ignoring the lint warnings for this. `// eslint-disable-next-line react-hooks/exhaustive-deps`.

This fixes the problem.

Related issue: https://github.com/PaulLeCam/react-leaflet/issues/1069