### PR TITLE
Allow customizing which class gets used for `LayersControl`

### DIFF
--- a/packages/react-leaflet/__tests__/LayersControl.tsx
+++ b/packages/react-leaflet/__tests__/LayersControl.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import L from 'leaflet'
+
+import { MapContainer, LayersControl, CustomizableLayersControl, TileLayer } from '../src'
+
+describe('LayersControl', () => {
+  test('renders Control.Layers', () => {
+    const { container } = render(
+      <MapContainer center={[0, 0]} zoom={10}>
+        <LayersControl>
+          <LayersControl.BaseLayer></LayersControl.BaseLayer>
+          <LayersControl.BaseLayer></LayersControl.BaseLayer>
+        </LayersControl>
+      </MapContainer>,
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
+  test('renders Custom class', () => {
+    const Control = CustomizableLayersControl(class extends L.Control.Layers {
+        _initLayout() {
+          this._container = L.DomUtil.create('ol')
+        }
+
+        _update() {
+          L.DomUtil.empty(this._container);
+          for (let i = 0; i < this._layers.length; ++i) {
+            this._container.appendChild(L.DomUtil.create('li'))
+          }
+        }
+      },
+    )
+
+    const { container } = render(
+      <MapContainer center={[0, 0]} zoom={10}>
+        <Control>
+          <Control.BaseLayer>
+            <TileLayer url="http://localhost/1" />
+          </Control.BaseLayer>
+          <Control.BaseLayer>
+            <TileLayer url="http://localhost/2" />
+          </Control.BaseLayer>
+        </Control>
+      </MapContainer>,
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/react-leaflet/__tests__/__snapshots__/LayersControl.tsx.snap
+++ b/packages/react-leaflet/__tests__/__snapshots__/LayersControl.tsx.snap
@@ -1,0 +1,226 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LayersControl renders Control.Layers 1`] = `
+<div>
+  <div
+    class="leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+    style="position: relative;"
+    tabindex="0"
+  >
+    <div
+      class="leaflet-pane leaflet-map-pane"
+      style="left: 0px; top: 0px;"
+    >
+      <div
+        class="leaflet-pane leaflet-tile-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-overlay-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-shadow-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-marker-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-tooltip-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-popup-pane"
+      />
+    </div>
+    <div
+      class="leaflet-control-container"
+    >
+      <div
+        class="leaflet-top leaflet-left"
+      >
+        <div
+          class="leaflet-control-zoom leaflet-bar leaflet-control"
+        >
+          <a
+            aria-disabled="false"
+            aria-label="Zoom in"
+            class="leaflet-control-zoom-in"
+            href="#"
+            role="button"
+            title="Zoom in"
+          >
+            <span
+              aria-hidden="true"
+            >
+              +
+            </span>
+          </a>
+          <a
+            aria-disabled="false"
+            aria-label="Zoom out"
+            class="leaflet-control-zoom-out"
+            href="#"
+            role="button"
+            title="Zoom out"
+          >
+            <span
+              aria-hidden="true"
+            >
+              −
+            </span>
+          </a>
+        </div>
+      </div>
+      <div
+        class="leaflet-top leaflet-right"
+      >
+        <div
+          aria-haspopup="true"
+          class="leaflet-control-layers leaflet-control"
+        >
+          <a
+            class="leaflet-control-layers-toggle"
+            href="#"
+            role="button"
+            title="Layers"
+          />
+          <section
+            class="leaflet-control-layers-list"
+          >
+            <div
+              class="leaflet-control-layers-base"
+            />
+            <div
+              class="leaflet-control-layers-separator"
+              style="display: none;"
+            />
+            <div
+              class="leaflet-control-layers-overlays"
+            />
+          </section>
+        </div>
+      </div>
+      <div
+        class="leaflet-bottom leaflet-left"
+      />
+      <div
+        class="leaflet-bottom leaflet-right"
+      >
+        <div
+          class="leaflet-control-attribution leaflet-control"
+        >
+          <a
+            href="https://leafletjs.com"
+            title="A JavaScript library for interactive maps"
+          >
+            Leaflet
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LayersControl renders Custom class 1`] = `
+<div>
+  <div
+    class="leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+    style="position: relative;"
+    tabindex="0"
+  >
+    <div
+      class="leaflet-pane leaflet-map-pane"
+      style="left: 0px; top: 0px;"
+    >
+      <div
+        class="leaflet-pane leaflet-tile-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-overlay-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-shadow-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-marker-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-tooltip-pane"
+      />
+      <div
+        class="leaflet-pane leaflet-popup-pane"
+      />
+    </div>
+    <div
+      class="leaflet-control-container"
+    >
+      <div
+        class="leaflet-top leaflet-left"
+      >
+        <div
+          class="leaflet-control-zoom leaflet-bar leaflet-control"
+        >
+          <a
+            aria-disabled="false"
+            aria-label="Zoom in"
+            class="leaflet-control-zoom-in"
+            href="#"
+            role="button"
+            title="Zoom in"
+          >
+            <span
+              aria-hidden="true"
+            >
+              +
+            </span>
+          </a>
+          <a
+            aria-disabled="false"
+            aria-label="Zoom out"
+            class="leaflet-control-zoom-out"
+            href="#"
+            role="button"
+            title="Zoom out"
+          >
+            <span
+              aria-hidden="true"
+            >
+              −
+            </span>
+          </a>
+        </div>
+      </div>
+      <div
+        class="leaflet-top leaflet-right"
+      >
+        <ol
+          class="leaflet-control"
+        >
+          <li
+            class=""
+          />
+          <li
+            class=""
+          />
+        </ol>
+      </div>
+      <div
+        class="leaflet-bottom leaflet-left"
+      />
+      <div
+        class="leaflet-bottom leaflet-right"
+      >
+        <div
+          class="leaflet-control-attribution leaflet-control"
+        >
+          <a
+            href="https://leafletjs.com"
+            title="A JavaScript library for interactive maps"
+          >
+            Leaflet
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-leaflet/src/index.ts
+++ b/packages/react-leaflet/src/index.ts
@@ -12,6 +12,7 @@ export { ImageOverlay, type ImageOverlayProps } from './ImageOverlay.js'
 export { LayerGroup, type LayerGroupProps } from './LayerGroup.js'
 export {
   LayersControl,
+  CustomizableLayersControl,
   type LayersControlProps,
   type ControlledLayerProps,
 } from './LayersControl.js'


### PR DESCRIPTION
My company wants to use images inside the `LayersControl`, so this is intended to allow customizing the underlying `L.Control` class that gets instantiated for the `<LayersControl>` provided by this library. Used as 

```
const MyLayersControl = CustomizableLayersControl(class extends L.Control.Layers {
  // ....
  // You'll likely want to override at least `_initLayout` and `_update`
});
```

See the added test for an example