### PR TITLE
Add draggable type to Marker

### DIFF
--- a/packages/react-leaflet/src/Marker.tsx
+++ b/packages/react-leaflet/src/Marker.tsx
@@ -14,6 +14,7 @@ import type { ReactNode } from 'react'
 export interface MarkerProps extends MarkerOptions, EventedProps {
   children?: ReactNode
   position: LatLngExpression
+  draggable?: Boolean
 }
 
 export const Marker = createLayerComponent<LeafletMarker, MarkerProps>(


### PR DESCRIPTION
The `draggable` prop on Marker is used in [this example in the docs](https://react-leaflet.js.org/docs/example-draggable-marker/) but the typing is not set on the Marker component:
```ts
Type '{ children: Element; draggable: boolean; position: never; ref: MutableRefObject<null>; eventHandlers: { dragend: () => void; }; }' is not assignable to type 'IntrinsicAttributes & MarkerProps & RefAttributes<LeafletMarker<any>>'.
  Property 'draggable' does not exist on type 'IntrinsicAttributes & MarkerProps & RefAttributes<LeafletMarker<any>>'.
  ```