### PR TITLE
Can't compare array with operator !==

### DIFF
--- a/packages/core/src/circle.ts
+++ b/packages/core/src/circle.ts
@@ -24,7 +24,7 @@ export function updateCircle<P extends CircleMarkerProps | CircleProps>(
   props: P,
   prevProps: P,
 ) {
-  if (props.center !== prevProps.center) {
+  if (props.center.toString() !== prevProps.center.toString()) {
     layer.setLatLng(props.center)
   }
   if (props.radius != null && props.radius !== prevProps.radius) {


### PR DESCRIPTION
The condition is already true and always force render of markers.
We should compare the array or object with toString() function.